### PR TITLE
Use a reference of problem for set_problem()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ mod tests {
         let y = solver.solve(&problem, t).unwrap();
 
         let mut state = OdeSolverState::new(&problem);
-        solver.set_problem(&mut state, problem);
+        solver.set_problem(&mut state, &problem);
         while state.t <= t {
             solver.step(&mut state).unwrap();
         }

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -259,9 +259,10 @@ where
     fn problem(&self) -> Option<&OdeSolverProblem<Eqn>> {
         self.ode_problem.as_ref()
     }
-
-    fn set_problem(&mut self, state: &mut OdeSolverState<Eqn::M>, problem: OdeSolverProblem<Eqn>) {
-        self.ode_problem = Some(problem);
+  
+    fn set_problem(&mut self, state: &mut OdeSolverState<Eqn::M>, problem: &OdeSolverProblem<Eqn>) {
+        let problem_clone = problem.clone();
+        self.ode_problem = Some(problem_clone);
         let problem = self.ode_problem.as_ref().unwrap();
         let nstates = problem.eqn.nstates();
         self.order = 1usize;

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -261,9 +261,7 @@ where
     }
   
     fn set_problem(&mut self, state: &mut OdeSolverState<Eqn::M>, problem: &OdeSolverProblem<Eqn>) {
-        let problem_clone = problem.clone();
-        self.ode_problem = Some(problem_clone);
-        let problem = self.ode_problem.as_ref().unwrap();
+        self.ode_problem = Some(problem.clone());
         let nstates = problem.eqn.nstates();
         self.order = 1usize;
         self.n_equal_steps = 0;

--- a/src/ode_solver/mod.rs
+++ b/src/ode_solver/mod.rs
@@ -44,7 +44,6 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
         t: Eqn::T,
         root_solver: &mut RS,
     ) -> Result<Eqn::V> {
-        let problem = problem.clone();
         let mut state = OdeSolverState::new_consistent(&problem, root_solver)?;
         self.set_problem(&mut state, &problem);
         while state.t <= t {

--- a/src/ode_solver/mod.rs
+++ b/src/ode_solver/mod.rs
@@ -26,13 +26,13 @@ pub mod diffsl;
 
 pub trait OdeSolverMethod<Eqn: OdeEquations> {
     fn problem(&self) -> Option<&OdeSolverProblem<Eqn>>;
-    fn set_problem(&mut self, state: &mut OdeSolverState<Eqn::M>, problem: OdeSolverProblem<Eqn>);
+    fn set_problem(&mut self, state: &mut OdeSolverState<Eqn::M>, problem: &OdeSolverProblem<Eqn>);
     fn step(&mut self, state: &mut OdeSolverState<Eqn::M>) -> Result<()>;
     fn interpolate(&self, state: &OdeSolverState<Eqn::M>, t: Eqn::T) -> Eqn::V;
     fn solve(&mut self, problem: &OdeSolverProblem<Eqn>, t: Eqn::T) -> Result<Eqn::V> {
         let problem = problem.clone();
         let mut state = OdeSolverState::new(&problem);
-        self.set_problem(&mut state, problem);
+        self.set_problem(&mut state, &problem);
         while state.t <= t {
             self.step(&mut state)?;
         }
@@ -46,7 +46,7 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
     ) -> Result<Eqn::V> {
         let problem = problem.clone();
         let mut state = OdeSolverState::new_consistent(&problem, root_solver)?;
-        self.set_problem(&mut state, problem);
+        self.set_problem(&mut state, &problem);
         while state.t <= t {
             self.step(&mut state)?;
         }
@@ -254,7 +254,7 @@ mod tests {
         Eqn: OdeEquations<M = M, T = M::T, V = M::V>,
     {
         let mut state = OdeSolverState::new_consistent(&problem, &mut root_solver).unwrap();
-        method.set_problem(&mut state, problem);
+        method.set_problem(&mut state, &problem);
         for point in solution.solution_points.iter() {
             while state.t < point.t {
                 method.step(&mut state).unwrap();

--- a/src/ode_solver/mod.rs
+++ b/src/ode_solver/mod.rs
@@ -30,7 +30,6 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
     fn step(&mut self, state: &mut OdeSolverState<Eqn::M>) -> Result<()>;
     fn interpolate(&self, state: &OdeSolverState<Eqn::M>, t: Eqn::T) -> Eqn::V;
     fn solve(&mut self, problem: &OdeSolverProblem<Eqn>, t: Eqn::T) -> Result<Eqn::V> {
-        let problem = problem.clone();
         let mut state = OdeSolverState::new(&problem);
         self.set_problem(&mut state, &problem);
         while state.t <= t {


### PR DESCRIPTION
During simulation it may be necessary to update the state, which also requires the problem. Previously `set_problem()` consumed `problem`, but this change instead calls for a reference. The problem itself is small, and as such the clone should not be especially expensive.