### PR TITLE
#15 add benchmarks using divan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,8 @@ sundials-sys = { version = "0.4.0", features = ["ida"], optional = true }
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["yaml"] }
+divan = "0.1.14"
+
+[[bench]]
+name = "solvers"
+harness = false

--- a/benches/solvers.rs
+++ b/benches/solvers.rs
@@ -1,0 +1,68 @@
+fn main() {
+    divan::main();
+}
+
+mod exponential_decay {
+    use diffsol::ode_solver::test_models::exponential_decay::exponential_decay_problem;
+    use diffsol::{Bdf, OdeSolverMethod};
+
+    #[divan::bench]
+    fn bdf() {
+        let mut s = Bdf::default();
+        let (problem, _soln) = exponential_decay_problem::<nalgebra::DMatrix<f64>>(false);
+        let _y = s.solve(&problem, 1.0);
+    }
+
+    #[cfg(feature = "sundials")]
+    #[divan::bench]
+    fn sundials() {
+        let mut s = diffsol::SundialsIda::default();
+        let (problem, _soln) = exponential_decay_problem::<diffsol::SundialsMatrix>(false);
+        let _y = s.solve(&problem, 1.0);
+    }
+}
+
+mod robertson_ode {
+    use diffsol::{ode_solver::test_models::robertson_ode::robertson_ode, Bdf, OdeSolverMethod};
+
+    #[divan::bench]
+    fn bdf() {
+        let mut s = Bdf::default();
+        let (problem, _soln) = robertson_ode::<nalgebra::DMatrix<f64>>(false);
+        let _y = s.solve(&problem, 1.0);
+    }
+
+    #[cfg(feature = "sundials")]
+    #[divan::bench]
+    fn sundials() {
+        let mut s = diffsol::SundialsIda::default();
+        let (problem, _soln) = robertson_ode::<diffsol::SundialsMatrix>(false);
+        let _y = s.solve(&problem, 1.0);
+    }
+}
+
+mod robertson {
+    use diffsol::{
+        ode_solver::test_models::robertson::robertson, Bdf, NewtonNonlinearSolver, OdeSolverMethod,
+        LU,
+    };
+
+    #[divan::bench]
+    fn bdf() {
+        let mut s = Bdf::default();
+        let (problem, _soln) = robertson::<nalgebra::DMatrix<f64>>(false);
+        let mut root = NewtonNonlinearSolver::new(LU::default());
+        let _y = s.make_consistent_and_solve(&problem, 1.0, &mut root);
+    }
+
+    #[cfg(feature = "sundials")]
+    #[divan::bench]
+    fn sundials() {
+        use diffsol::SundialsLinearSolver;
+
+        let mut s = diffsol::SundialsIda::default();
+        let (problem, _soln) = robertson::<diffsol::SundialsMatrix>(false);
+        let mut root = NewtonNonlinearSolver::new(SundialsLinearSolver::new_dense());
+        let _y = s.make_consistent_and_solve(&problem, 1.0, &mut root);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@ pub use linear_solver::lu::LU;
 use linear_solver::LinearSolver;
 
 #[cfg(feature = "sundials")]
-use matrix::sundials::SundialsMatrix;
+pub use matrix::sundials::SundialsMatrix;
 
 #[cfg(feature = "sundials")]
-use vector::sundials::SundialsVector;
+pub use vector::sundials::SundialsVector;
 
 #[cfg(feature = "sundials")]
 pub use linear_solver::sundials::SundialsLinearSolver;
@@ -53,7 +53,8 @@ pub use linear_solver::sundials::SundialsLinearSolver;
 pub use ode_solver::sundials::SundialsIda;
 
 use matrix::{DenseMatrix, Matrix, MatrixViewMut};
-use nonlinear_solver::{newton::NewtonNonlinearSolver, NonLinearSolver};
+pub use nonlinear_solver::newton::NewtonNonlinearSolver;
+use nonlinear_solver::NonLinearSolver;
 pub use ode_solver::{
     bdf::Bdf, equations::OdeEquations, OdeSolverMethod, OdeSolverProblem, OdeSolverState,
 };

--- a/src/ode_solver/test_models/robertson_ode.rs
+++ b/src/ode_solver/test_models/robertson_ode.rs
@@ -1,10 +1,9 @@
 use crate::{
-    matrix::DenseMatrix,
     ode_solver::{OdeBuilder, OdeSolverProblem, OdeSolverSolution},
-    OdeEquations, Vector,
+    Matrix, OdeEquations, Vector,
 };
 
-pub fn robertson_ode<M: DenseMatrix + 'static>(
+pub fn robertson_ode<M: Matrix + 'static>(
     use_coloring: bool,
 ) -> (
     OdeSolverProblem<impl OdeEquations<M = M, V = M::V, T = M::T>>,


### PR DESCRIPTION
Fixes #15

on my machine its:

solvers               fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ exponential_decay                │               │               │               │         │
│  ├─ bdf             15.68 µs      │ 135.3 µs      │ 16.07 µs      │ 17.62 µs      │ 100     │ 100
│  ╰─ sundials        28.43 µs      │ 142.4 µs      │ 29.88 µs      │ 31.63 µs      │ 100     │ 100
├─ robertson                        │               │               │               │         │
│  ├─ bdf             62.89 µs      │ 113.7 µs      │ 64.03 µs      │ 65.9 µs       │ 100     │ 100
│  ╰─ sundials        56.82 µs      │ 84.68 µs      │ 58.83 µs      │ 60.44 µs      │ 100     │ 100
╰─ robertson_ode                    │               │               │               │         │
   ├─ bdf             35.97 µs      │ 63.26 µs      │ 36.46 µs      │ 37.42 µs      │ 100     │ 100
   ╰─ sundials        48.28 µs      │ 59.77 µs      │ 49.85 µs      │ 50.58 µs      │ 100     │ 100
