### PR TITLE
in order to allow external crates to implement their own interfaces, this function needs to be public

### DIFF
--- a/src/ode_solver/equations.rs
+++ b/src/ode_solver/equations.rs
@@ -98,7 +98,7 @@ where
     I: Fn(&M::V, M::T) -> M::V,
 {
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub fn new(
         rhs: Rc<Rhs>,
         mass: Rc<Mass>,
         root: Option<Rc<Root>>,


### PR DESCRIPTION
As discussed