### PR TITLE
Compatible with nalgebra 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ diffsl-llvm16 = ["diffsl16-0", "diffsl"]
 diffsl-llvm17 = ["diffsl17-0", "diffsl"]
 
 [dependencies]
-nalgebra = ">=0.32"
-nalgebra-sparse = ">=0.9"
-anyhow = ">=1.0.77"
+nalgebra = "0.33"
+nalgebra-sparse = "0.10"
+anyhow = "1.0.86"
 num-traits = "0.2.17"
 ouroboros = "0.18.2"
 serde = { version = "1.0.196", features = ["derive"] }

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
-use nalgebra::{ClosedAdd, ClosedDiv, ClosedMul, ClosedSub, ComplexField, SimdRealField};
+use nalgebra::{ComplexField, SimdRealField};
 use num_traits::{Pow, Signed};
 
 use crate::vector::VectorView;
@@ -19,11 +19,7 @@ pub trait Scalar:
     + SimdRealField
     + ComplexField<RealField = Self>
     + Copy
-    + ClosedSub
     + From<f64>
-    + ClosedMul
-    + ClosedDiv
-    + ClosedAdd
     + Signed
     + Into<f64>
     + PartialOrd


### PR DESCRIPTION
This updates diffsol to use nalgebra 0.33, and removes the ">=" version requirement for other dependencies, as it is prone to breaking changes like this one.