### PR TITLE
Migrate from `anyhow` to `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ diffsl-llvm17 = ["diffsl17-0", "diffsl"]
 [dependencies]
 nalgebra = "0.33"
 nalgebra-sparse = { version = "0.10", features = ["io"] }
-anyhow = "1.0.86"
 num-traits = "0.2.17"
 ouroboros = "0.18.2"
 serde = { version = "1.0.196", features = ["derive"] }
@@ -38,6 +37,7 @@ diffsl17-0 = { package = "diffsl", version = "=0.1.9", features = ["llvm17-0"], 
 petgraph = "0.6.4"
 faer = "0.18.2"
 suitesparse_sys = { version = "0.1.3", optional = true }
+thiserror = "1.0.63"
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["yaml"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,7 +94,7 @@ pub enum MatrixError {
     MatrixShapeError,
     #[error("Index out of bounds")]
     IndexOutOfBounds,
-    #[error("Other error: {0}")]
+    #[error("Error: {0}")]
     Other(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum DiffsolError {
     OdeSolverError(#[from] OdeSolverError),
     #[error("Matrix error: {0}")]
     MatrixError(#[from] MatrixError),
-    #[error("Other error: {0}")]
+    #[error("Error: {0}")]
     Other(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ pub enum LinearSolverError {
 /// Possible errors that can occur when solving a non-linear problem
 #[derive(Error, Debug)]
 pub enum NonLinearSolverError {
-    #[error("Newton did not converge")]
+    #[error("Newton iterations did not converge")]
     NewtonDidNotConverge,
     #[error("LU solve failed")]
     LuSolveFailed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum LinearSolverError {
     KluFailedToAnalyze,
     #[error("KLU failed to factorize")]
     KluFailedToFactorize,
-    #[error("Other error: {0}")]
+    #[error("Error: {0}")]
     Other(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,3 +83,50 @@ pub enum MatrixError {
     #[error("Other error: {0}")]
     Other(String),
 }
+
+#[macro_export]
+macro_rules! linear_solver_error {
+    ($variant:ident) => {
+        DiffsolError::from(LinearSolverError::$variant)
+    };
+    ($variant:ident, $($arg:tt)*) => {
+        DiffsolError::from(LinearSolverError::$variant($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! non_linear_solver_error {
+    ($variant:ident) => {
+        DiffsolError::from(NonLinearSolverError::$variant)
+    };
+    ($variant:ident, $($arg:tt)*) => {
+        DiffsolError::from(NonLinearSolverError::$variant($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! ode_solver_error {
+    ($variant:ident) => {
+        DiffsolError::from(OdeSolverError::$variant)
+    };
+    ($variant:ident, $($arg:tt)*) => {
+        DiffsolError::from(OdeSolverError::$variant($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! matrix_error {
+    ($variant:ident) => {
+        DiffsolError::from(MatrixError::$variant)
+    };
+    ($variant:ident, $($arg:tt)*) => {
+        DiffsolError::from(MatrixError::$variant($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! other_error {
+    ($msg:expr) => {
+        DiffsolError::Other($msg.to_string())
+    };
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,7 +124,7 @@ macro_rules! ode_solver_error {
         DiffsolError::from(OdeSolverError::$variant)
     };
     ($variant:ident, $($arg:tt)*) => {
-        DiffsolError::from(OdeSolverError::$variant($($arg)*))
+        DiffsolError::from(OdeSolverError::$variant($($arg)*.to_string()))
     };
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,9 @@
 use faer::sparse::CreationError;
 use thiserror::Error;
 
+/// Custom error type for Diffsol
+///
+/// This error type is used to wrap all possible errors that can occur when using Diffsol
 #[derive(thiserror::Error, Debug)]
 pub enum DiffsolError {
     #[error("Linear solver error: {0}")]
@@ -18,25 +21,26 @@ pub enum DiffsolError {
 /// Possible errors that can occur when solving a linear problem
 #[derive(Error, Debug)]
 pub enum LinearSolverError {
-    #[error("template")]
-    Template,
     #[error("LU not initialized")]
     LuNotInitialized,
     #[error("LU solve failed")]
     LuSolveFailed,
+    #[error("Other error: {0}")]
+    Other(String),
 }
 
 /// Possible errors that can occur when solving a non-linear problem
 #[derive(Error, Debug)]
 pub enum NonLinearSolverError {
-    #[error("template")]
-    Template,
     #[error("Newton did not converge")]
     NewtonDidNotConverge,
     #[error("LU solve failed")]
     LuSolveFailed,
+    #[error("Other error: {0}")]
+    Other(String),
 }
 
+/// Possible errors that can occur when solving an ODE
 #[derive(Debug, Error)]
 pub enum OdeSolverError {
     #[error(
@@ -63,9 +67,11 @@ pub enum OdeSolverError {
     AtolLengthMismatch,
     #[error("t_eval must be increasing and all values must be greater than or equal to the current time")]
     InvalidTEval,
+    #[error("Other error: {0}")]
+    Other(String),
 }
 
-/// Possible errors that can occur when solving a non-linear problem
+/// Possible errors for matrix operations
 #[derive(Error, Debug)]
 pub enum MatrixError {
     #[error("Failed to create matrix from triplets: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,7 +79,7 @@ pub enum OdeSolverError {
     SundialsError(String),
     #[error("Problem not set")]
     ProblemNotSet,
-    #[error("Other error: {0}")]
+    #[error("Error: {0}")]
     Other(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ pub enum NonLinearSolverError {
     NewtonDidNotConverge,
     #[error("LU solve failed")]
     LuSolveFailed,
-    #[error("Other error: {0}")]
+    #[error("Error: {0}")]
     Other(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,7 +76,7 @@ pub enum OdeSolverError {
     #[error("t_eval must be increasing and all values must be greater than or equal to the current time")]
     InvalidTEval,
     #[error("Sundials error: {0}")]
-    Sundials(String),
+    SundialsError(String),
     #[error("Problem not set")]
     ProblemNotSet,
     #[error("Other error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 /// Custom error type for Diffsol
 ///
 /// This error type is used to wrap all possible errors that can occur when using Diffsol
-#[derive(thiserror::Error, Debug)]
+#[derive(Error, Debug)]
 pub enum DiffsolError {
     #[error("Linear solver error: {0}")]
     LinearSolverError(#[from] LinearSolverError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
+use faer::sparse::CreationError;
 use thiserror::Error;
-use faer::sparse::CreationError as CreationError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DiffsolError {
@@ -65,7 +65,6 @@ pub enum OdeSolverError {
     InvalidTEval,
 }
 
-
 /// Possible errors that can occur when solving a non-linear problem
 #[derive(Error, Debug)]
 pub enum MatrixError {
@@ -77,5 +76,4 @@ pub enum MatrixError {
     MatrixShapeError,
     #[error("Other error: {0}")]
     Other(String),
-
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,81 @@
+use thiserror::Error;
+use faer::sparse::CreationError as CreationError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DiffsolError {
+    #[error("Linear solver error: {0}")]
+    LinearSolverError(#[from] LinearSolverError),
+    #[error("Non-linear solver error: {0}")]
+    NonLinearSolverError(#[from] NonLinearSolverError),
+    #[error("ODE solver error: {0}")]
+    OdeSolverError(#[from] OdeSolverError),
+    #[error("Matrix error: {0}")]
+    MatrixError(#[from] MatrixError),
+    #[error("Other error: {0}")]
+    Other(String),
+}
+
+/// Possible errors that can occur when solving a linear problem
+#[derive(Error, Debug)]
+pub enum LinearSolverError {
+    #[error("template")]
+    Template,
+    #[error("LU not initialized")]
+    LuNotInitialized,
+    #[error("LU solve failed")]
+    LuSolveFailed,
+}
+
+/// Possible errors that can occur when solving a non-linear problem
+#[derive(Error, Debug)]
+pub enum NonLinearSolverError {
+    #[error("template")]
+    Template,
+    #[error("Newton did not converge")]
+    NewtonDidNotConverge,
+    #[error("LU solve failed")]
+    LuSolveFailed,
+}
+
+#[derive(Debug, Error)]
+pub enum OdeSolverError {
+    #[error(
+        "Stop time = {} is less than current state time = {}",
+        stop_time,
+        state_time
+    )]
+    StopTimeBeforeCurrentTime { stop_time: f64, state_time: f64 },
+    #[error("Interpolation time is after current time")]
+    InterpolationTimeAfterCurrentTime,
+    #[error("Interpolation time is not within the current step. Step size is zero after calling state_mut()")]
+    InterpolationTimeOutsideCurrentStep,
+    #[error("State not set")]
+    StateNotSet,
+    #[error("Sensitivity solve failed")]
+    SensitivitySolveFailed,
+    #[error("Step size is too small at time = {time}")]
+    StepSizeTooSmall { time: f64 },
+    #[error("Sensitivity requested but equations do not support it")]
+    SensitivityNotSupported,
+    #[error("Failed to get mutable reference to equations, is there a solver created with this problem?")]
+    FailedToGetMutableReference,
+    #[error("atol must have length 1 or equal to the number of states")]
+    AtolLengthMismatch,
+    #[error("t_eval must be increasing and all values must be greater than or equal to the current time")]
+    InvalidTEval,
+}
+
+
+/// Possible errors that can occur when solving a non-linear problem
+#[derive(Error, Debug)]
+pub enum MatrixError {
+    #[error("Failed to create matrix from triplets: {0}")]
+    FailedToCreateMatrixFromTriplets(#[from] CreationError),
+    #[error("Cannot union matrices with different shapes")]
+    UnionIncompatibleShapes,
+    #[error("Cannot create a matrix with zero rows or columns")]
+    MatrixShapeError,
+    #[error("Other error: {0}")]
+    Other(String),
+
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,12 @@ pub enum LinearSolverError {
     LuNotInitialized,
     #[error("LU solve failed")]
     LuSolveFailed,
+    #[error("Linear solver not setup")]
+    LinearSolverNotSetup,
+    #[error("KLU failed to analyze")]
+    KluFailedToAnalyze,
+    #[error("KLU failed to factorize")]
+    KluFailedToFactorize,
     #[error("Other error: {0}")]
     Other(String),
 }
@@ -53,6 +59,8 @@ pub enum OdeSolverError {
     InterpolationTimeAfterCurrentTime,
     #[error("Interpolation time is not within the current step. Step size is zero after calling state_mut()")]
     InterpolationTimeOutsideCurrentStep,
+    #[error("Interpolation time is greater than current time")]
+    InterpolationTimeGreaterThanCurrentTime,
     #[error("State not set")]
     StateNotSet,
     #[error("Sensitivity solve failed")]
@@ -67,6 +75,10 @@ pub enum OdeSolverError {
     AtolLengthMismatch,
     #[error("t_eval must be increasing and all values must be greater than or equal to the current time")]
     InvalidTEval,
+    #[error("Sundials error: {0}")]
+    Sundials(String),
+    #[error("Problem not set")]
+    ProblemNotSet,
     #[error("Other error: {0}")]
     Other(String),
 }
@@ -80,6 +92,8 @@ pub enum MatrixError {
     UnionIncompatibleShapes,
     #[error("Cannot create a matrix with zero rows or columns")]
     MatrixShapeError,
+    #[error("Index out of bounds")]
+    IndexOutOfBounds,
     #[error("Other error: {0}")]
     Other(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,3 +170,5 @@ pub use vector::DefaultDenseMatrix;
 use vector::{Vector, VectorCommon, VectorIndex, VectorRef, VectorView, VectorViewMut};
 
 pub use scalar::scale;
+
+pub mod error;

--- a/src/linear_solver/faer/lu.rs
+++ b/src/linear_solver/faer/lu.rs
@@ -1,4 +1,4 @@
-use crate::error::LinearSolverError;
+use crate::{error::LinearSolverError, linear_solver_error};
 use std::rc::Rc;
 
 use crate::{
@@ -44,8 +44,7 @@ impl<T: Scalar, C: NonLinearOp<M = Mat<T>, V = Col<T>, T = T>> LinearSolver<C> f
 
     fn solve_in_place(&self, x: &mut C::V) -> Result<(), DiffsolError> {
         if self.lu.is_none() {
-            let error = LinearSolverError::LuNotInitialized;
-            return Err(DiffsolError::from(error))?;
+            return Err(linear_solver_error!(LuNotInitialized))?;
         }
         let lu = self.lu.as_ref().unwrap();
         lu.solve_in_place(x);

--- a/src/linear_solver/faer/sparse_lu.rs
+++ b/src/linear_solver/faer/sparse_lu.rs
@@ -1,11 +1,15 @@
 use std::rc::Rc;
 
 use crate::{
-    linear_solver::LinearSolver, matrix::sparsity::MatrixSparsityRef, op::linearise::LinearisedOp,
-    scalar::IndexType, solver::SolverProblem, LinearOp, Matrix, NonLinearOp, Op, Scalar,
-    SparseColMat,
+    error::{DiffsolError, LinearSolverError},
+    linear_solver::LinearSolver,
+    matrix::sparsity::MatrixSparsityRef,
+    op::linearise::LinearisedOp,
+    scalar::IndexType,
+    solver::SolverProblem,
+    LinearOp, Matrix, NonLinearOp, Op, Scalar, SparseColMat,
 };
-use anyhow::Result;
+
 use faer::{
     solvers::SpSolver,
     sparse::linalg::{solvers::Lu, solvers::SymbolicLu},
@@ -57,9 +61,10 @@ impl<T: Scalar, C: NonLinearOp<M = SparseColMat<T>, V = Col<T>, T = T>> LinearSo
         )
     }
 
-    fn solve_in_place(&self, x: &mut C::V) -> Result<()> {
+    fn solve_in_place(&self, x: &mut C::V) -> Result<(), DiffsolError> {
         if self.lu.is_none() {
-            return Err(anyhow::anyhow!("LU not initialized"));
+            let error = LinearSolverError::LuNotInitialized;
+            return Err(DiffsolError::from(error));
         }
         let lu = self.lu.as_ref().unwrap();
         lu.solve_in_place(x);

--- a/src/linear_solver/faer/sparse_lu.rs
+++ b/src/linear_solver/faer/sparse_lu.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use crate::{
     error::{DiffsolError, LinearSolverError},
     linear_solver::LinearSolver,
+    linear_solver_error,
     matrix::sparsity::MatrixSparsityRef,
     op::linearise::LinearisedOp,
     scalar::IndexType,
@@ -63,8 +64,7 @@ impl<T: Scalar, C: NonLinearOp<M = SparseColMat<T>, V = Col<T>, T = T>> LinearSo
 
     fn solve_in_place(&self, x: &mut C::V) -> Result<(), DiffsolError> {
         if self.lu.is_none() {
-            let error = LinearSolverError::LuNotInitialized;
-            return Err(DiffsolError::from(error));
+            return Err(linear_solver_error!(LuNotInitialized))?;
         }
         let lu = self.lu.as_ref().unwrap();
         lu.solve_in_place(x);

--- a/src/linear_solver/mod.rs
+++ b/src/linear_solver/mod.rs
@@ -1,5 +1,4 @@
-use crate::{op::Op, solver::SolverProblem};
-use anyhow::Result;
+use crate::{error::DiffsolError, op::Op, solver::SolverProblem};
 
 #[cfg(feature = "nalgebra")]
 pub mod nalgebra;
@@ -27,13 +26,13 @@ pub trait LinearSolver<C: Op> {
 
     /// Solve the problem `Ax = b` and return the solution `x`.
     /// panics if [Self::set_linearisation] has not been called previously
-    fn solve(&self, b: &C::V) -> Result<C::V> {
+    fn solve(&self, b: &C::V) -> Result<C::V, DiffsolError> {
         let mut b = b.clone();
         self.solve_in_place(&mut b)?;
         Ok(b)
     }
 
-    fn solve_in_place(&self, b: &mut C::V) -> Result<()>;
+    fn solve_in_place(&self, b: &mut C::V) -> Result<(), DiffsolError>;
 }
 
 pub struct LinearSolveSolution<V> {

--- a/src/linear_solver/nalgebra/lu.rs
+++ b/src/linear_solver/nalgebra/lu.rs
@@ -1,9 +1,8 @@
+use nalgebra::{DMatrix, DVector, Dyn};
 use std::rc::Rc;
 
-use anyhow::Result;
-use nalgebra::{DMatrix, DVector, Dyn};
-
 use crate::{
+    error::{DiffsolError, LinearSolverError},
     matrix::sparsity::MatrixSparsityRef,
     op::{linearise::LinearisedOp, NonLinearOp},
     LinearOp, LinearSolver, Matrix, Op, Scalar, SolverProblem,
@@ -37,14 +36,14 @@ where
 impl<T: Scalar, C: NonLinearOp<M = DMatrix<T>, V = DVector<T>, T = T>> LinearSolver<C>
     for LU<T, C>
 {
-    fn solve_in_place(&self, state: &mut C::V) -> Result<()> {
+    fn solve_in_place(&self, state: &mut C::V) -> Result<(), DiffsolError> {
         if self.lu.is_none() {
-            return Err(anyhow::anyhow!("LU not initialized"));
+            return Err(DiffsolError::from(LinearSolverError::LuNotInitialized));
         }
         let lu = self.lu.as_ref().unwrap();
         match lu.solve_mut(state) {
             true => Ok(()),
-            false => Err(anyhow::anyhow!("LU solve failed")),
+            false => Err(DiffsolError::from(LinearSolverError::LuSolveFailed)),
         }
     }
 

--- a/src/linear_solver/nalgebra/lu.rs
+++ b/src/linear_solver/nalgebra/lu.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use crate::{
     error::{DiffsolError, LinearSolverError},
+    linear_solver_error,
     matrix::sparsity::MatrixSparsityRef,
     op::{linearise::LinearisedOp, NonLinearOp},
     LinearOp, LinearSolver, Matrix, Op, Scalar, SolverProblem,
@@ -38,12 +39,12 @@ impl<T: Scalar, C: NonLinearOp<M = DMatrix<T>, V = DVector<T>, T = T>> LinearSol
 {
     fn solve_in_place(&self, state: &mut C::V) -> Result<(), DiffsolError> {
         if self.lu.is_none() {
-            return Err(DiffsolError::from(LinearSolverError::LuNotInitialized));
+            return Err(linear_solver_error!(LuNotInitialized))?;
         }
         let lu = self.lu.as_ref().unwrap();
         match lu.solve_mut(state) {
             true => Ok(()),
-            false => Err(DiffsolError::from(LinearSolverError::LuSolveFailed)),
+            false => Err(linear_solver_error!(LuSolveFailed))?,
         }
     }
 

--- a/src/linear_solver/suitesparse/klu.rs
+++ b/src/linear_solver/suitesparse/klu.rs
@@ -1,7 +1,5 @@
 use std::{cell::RefCell, rc::Rc};
 
-use anyhow::Result;
-
 use faer::Col;
 
 #[cfg(target_pointer_width = "32")]

--- a/src/linear_solver/suitesparse/klu.rs
+++ b/src/linear_solver/suitesparse/klu.rs
@@ -23,8 +23,9 @@ use suitesparse_sys::{
 type KluIndextype = i64;
 
 use crate::{
-    linear_solver::LinearSolver, matrix::MatrixCommon, op::linearise::LinearisedOp, vector::Vector,
-    LinearOp, Matrix, MatrixSparsityRef, NonLinearOp, Op, SolverProblem, SparseColMat,
+    error::DiffsolError, linear_solver::LinearSolver, linear_solver_error, matrix::MatrixCommon,
+    op::linearise::LinearisedOp, vector::Vector, LinearOp, Matrix, MatrixSparsityRef, NonLinearOp,
+    Op, SolverProblem, SparseColMat,
 };
 
 trait MatrixKLU: Matrix<T = f64> {
@@ -198,7 +199,7 @@ where
         .ok();
     }
 
-    fn solve_in_place(&self, x: &mut C::V) -> Result<()> {
+    fn solve_in_place(&self, x: &mut C::V) -> Result<(), DiffsolError> {
         if self.klu_numeric.is_none() {
             return Err(linear_solver_error!(LuNotInitialized));
         }

--- a/src/linear_solver/suitesparse/klu.rs
+++ b/src/linear_solver/suitesparse/klu.rs
@@ -66,7 +66,10 @@ struct KluSymbolic {
 }
 
 impl KluSymbolic {
-    fn try_from_matrix(mat: &mut impl MatrixKLU, common: *mut klu_common) -> Result<Self, DiffsolError> {
+    fn try_from_matrix(
+        mat: &mut impl MatrixKLU,
+        common: *mut klu_common,
+    ) -> Result<Self, DiffsolError> {
         let n = mat.nrows() as i64;
         let inner = unsafe {
             klu_analyze(
@@ -97,7 +100,10 @@ struct KluNumeric {
 }
 
 impl KluNumeric {
-    fn try_from_symbolic(symbolic: &mut KluSymbolic, mat: &mut impl MatrixKLU) -> Result<Self, DiffsolError> {
+    fn try_from_symbolic(
+        symbolic: &mut KluSymbolic,
+        mat: &mut impl MatrixKLU,
+    ) -> Result<Self, DiffsolError> {
         let inner = unsafe {
             klu_factor(
                 mat.column_pointers_mut_ptr(),
@@ -192,7 +198,7 @@ where
         .ok();
     }
 
-    fn solve_in_place(&self, x: &mut C::V) -> Result<(),> {
+    fn solve_in_place(&self, x: &mut C::V) -> Result<()> {
         if self.klu_numeric.is_none() {
             return Err(linear_solver_error!(LuNotInitialized));
         }

--- a/src/linear_solver/suitesparse/klu.rs
+++ b/src/linear_solver/suitesparse/klu.rs
@@ -23,9 +23,13 @@ use suitesparse_sys::{
 type KluIndextype = i64;
 
 use crate::{
-    error::DiffsolError, linear_solver::LinearSolver, linear_solver_error, matrix::MatrixCommon,
-    op::linearise::LinearisedOp, vector::Vector, LinearOp, Matrix, MatrixSparsityRef, NonLinearOp,
-    Op, SolverProblem, SparseColMat,
+    error::{DiffsolError, LinearSolverError},
+    linear_solver::LinearSolver,
+    linear_solver_error,
+    matrix::MatrixCommon,
+    op::linearise::LinearisedOp,
+    vector::Vector,
+    LinearOp, Matrix, MatrixSparsityRef, NonLinearOp, Op, SolverProblem, SparseColMat,
 };
 
 trait MatrixKLU: Matrix<T = f64> {

--- a/src/linear_solver/sundials.rs
+++ b/src/linear_solver/sundials.rs
@@ -5,9 +5,9 @@ use crate::sundials_sys::{
 };
 
 use crate::{
-    ode_solver::sundials::sundials_check, op::linearise::LinearisedOp,
-    vector::sundials::SundialsVector, LinearOp, Matrix, NonLinearOp, Op, SolverProblem,
-    SundialsMatrix,
+    error::*, linear_solver_error, ode_solver::sundials::sundials_check,
+    ode_solver_error, op::linearise::LinearisedOp, vector::sundials::SundialsVector, LinearOp,
+    Matrix, NonLinearOp, Op, SolverProblem, SundialsMatrix,
 };
 
 #[cfg(not(sundials_version_major = "5"))]

--- a/src/linear_solver/sundials.rs
+++ b/src/linear_solver/sundials.rs
@@ -5,7 +5,7 @@ use crate::sundials_sys::{
 };
 
 use crate::{
-    error::*, linear_solver_error, ode_solver::sundials::sundials_check, ode_solver_error,
+    error::*, linear_solver_error, ode_solver::sundials::sundials_check,
     op::linearise::LinearisedOp, vector::sundials::SundialsVector, LinearOp, Matrix, NonLinearOp,
     Op, SolverProblem, SundialsMatrix,
 };

--- a/src/linear_solver/sundials.rs
+++ b/src/linear_solver/sundials.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 use crate::sundials_sys::{
     realtype, SUNLinSolFree, SUNLinSolSetup, SUNLinSolSolve, SUNLinSol_Dense, SUNLinearSolver,
 };
-use anyhow::Result;
 
 use crate::{
     ode_solver::sundials::sundials_check, op::linearise::LinearisedOp,

--- a/src/linear_solver/sundials.rs
+++ b/src/linear_solver/sundials.rs
@@ -5,9 +5,9 @@ use crate::sundials_sys::{
 };
 
 use crate::{
-    error::*, linear_solver_error, ode_solver::sundials::sundials_check,
-    ode_solver_error, op::linearise::LinearisedOp, vector::sundials::SundialsVector, LinearOp,
-    Matrix, NonLinearOp, Op, SolverProblem, SundialsMatrix,
+    error::*, linear_solver_error, ode_solver::sundials::sundials_check, ode_solver_error,
+    op::linearise::LinearisedOp, vector::sundials::SundialsVector, LinearOp, Matrix, NonLinearOp,
+    Op, SolverProblem, SundialsMatrix,
 };
 
 #[cfg(not(sundials_version_major = "5"))]

--- a/src/linear_solver/sundials.rs
+++ b/src/linear_solver/sundials.rs
@@ -97,9 +97,9 @@ where
         self.is_setup = true;
     }
 
-    fn solve_in_place(&self, b: &mut Op::V) -> Result<()> {
+    fn solve_in_place(&self, b: &mut Op::V) -> Result<(), DiffsolError> {
         if !self.is_setup {
-            return Err(anyhow::anyhow!("Linear solver not setup"));
+            return Err(linear_solver_error!(LinearSolverNotSetup));
         }
         let linear_solver = self.linear_solver.expect("Linear solver not set");
         let matrix = self.matrix.as_ref().expect("Matrix not set");

--- a/src/matrix/dense_faer_serial.rs
+++ b/src/matrix/dense_faer_serial.rs
@@ -2,11 +2,12 @@ use std::ops::{AddAssign, Mul, MulAssign};
 
 use super::default_solver::DefaultSolver;
 use super::{DenseMatrix, Matrix, MatrixCommon, MatrixView, MatrixViewMut};
+use crate::error::DiffsolError;
 use crate::op::NonLinearOp;
 use crate::scalar::{IndexType, Scalar, Scale};
 use crate::FaerLU;
 use crate::{Dense, DenseRef, Vector};
-use anyhow::Result;
+
 use faer::{
     linalg::matmul::matmul, mat::As2D, mat::As2DMut, Col, ColMut, ColRef, Mat, MatMut, MatRef,
     Parallelism,
@@ -197,7 +198,7 @@ impl<T: Scalar> Matrix for Mat<T> {
         nrows: IndexType,
         ncols: IndexType,
         triplets: Vec<(IndexType, IndexType, T)>,
-    ) -> Result<Self> {
+    ) -> Result<Self, DiffsolError> {
         let mut m = Self::zeros(nrows, ncols);
         for (i, j, v) in triplets {
             m[(i, j)] = v;

--- a/src/matrix/dense_nalgebra_serial.rs
+++ b/src/matrix/dense_nalgebra_serial.rs
@@ -1,6 +1,5 @@
 use std::ops::{AddAssign, Mul, MulAssign};
 
-use anyhow::Result;
 use nalgebra::{
     DMatrix, DMatrixView, DMatrixViewMut, DVector, DVectorView, DVectorViewMut, RawStorage,
     RawStorageMut,
@@ -10,10 +9,10 @@ use crate::op::NonLinearOp;
 use crate::vector::Vector;
 use crate::{scalar::Scale, IndexType, Scalar};
 
-use crate::{DenseMatrix, Matrix, MatrixCommon, MatrixView, MatrixViewMut, NalgebraLU};
-
 use super::default_solver::DefaultSolver;
 use super::sparsity::{Dense, DenseRef};
+use crate::error::DiffsolError;
+use crate::{DenseMatrix, Matrix, MatrixCommon, MatrixView, MatrixViewMut, NalgebraLU};
 
 impl<T: Scalar> DefaultSolver for DMatrix<T> {
     type LS<C: NonLinearOp<M = DMatrix<T>, V = DVector<T>, T = T>> = NalgebraLU<T, C>;
@@ -131,7 +130,7 @@ impl<T: Scalar> Matrix for DMatrix<T> {
         nrows: IndexType,
         ncols: IndexType,
         triplets: Vec<(IndexType, IndexType, T)>,
-    ) -> Result<Self> {
+    ) -> Result<Self, DiffsolError> {
         let mut m = Self::zeros(nrows, ncols);
         for (i, j, v) in triplets {
             m[(i, j)] = v;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -1,9 +1,10 @@
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Index, IndexMut, Mul, MulAssign, Sub, SubAssign};
 
+use crate::error::DiffsolError;
 use crate::scalar::Scale;
 use crate::{IndexType, Scalar, Vector, VectorIndex};
-use anyhow::Result;
+
 use num_traits::{One, Zero};
 use sparsity::{MatrixSparsity, MatrixSparsityRef};
 
@@ -292,7 +293,7 @@ pub trait Matrix: MatrixCommon + Mul<Scale<Self::T>, Output = Self> + Clone {
         nrows: IndexType,
         ncols: IndexType,
         triplets: Vec<(IndexType, IndexType, Self::T)>,
-    ) -> Result<Self>;
+    ) -> Result<Self, DiffsolError>;
 }
 
 /// A dense column-major matrix. The assumption is that the underlying matrix is stored in column-major order, so functions for taking columns views are efficient

--- a/src/matrix/sparse_faer.rs
+++ b/src/matrix/sparse_faer.rs
@@ -3,9 +3,10 @@ use std::ops::Mul;
 
 use super::sparsity::MatrixSparsityRef;
 use super::{Matrix, MatrixCommon, MatrixSparsity};
+use crate::error::{DiffsolError, MatrixError};
 use crate::vector::Vector;
 use crate::{DefaultSolver, FaerSparseLU, IndexType, NonLinearOp, Scalar, Scale};
-use anyhow::Result;
+
 use faer::sparse::ops::{ternary_op_assign_into, union_symbolic};
 use faer::sparse::{SymbolicSparseColMat, SymbolicSparseColMatRef};
 use faer::Col;
@@ -55,8 +56,8 @@ impl<T: Scalar> MatrixSparsity<SparseColMat<T>> for SymbolicSparseColMat<IndexTy
     fn union(
         self,
         other: SymbolicSparseColMatRef<IndexType>,
-    ) -> Result<SymbolicSparseColMat<IndexType>> {
-        union_symbolic(self.as_ref(), other).map_err(anyhow::Error::new)
+    ) -> Result<SymbolicSparseColMat<IndexType>, DiffsolError> {
+        union_symbolic(self.as_ref(), other).map_err(|e| DiffsolError::Other(e.to_string()))
     }
 
     fn as_ref(&self) -> SymbolicSparseColMatRef<IndexType> {
@@ -96,10 +97,10 @@ impl<T: Scalar> MatrixSparsity<SparseColMat<T>> for SymbolicSparseColMat<IndexTy
         nrows: IndexType,
         ncols: IndexType,
         indices: Vec<(IndexType, IndexType)>,
-    ) -> Result<Self> {
+    ) -> Result<Self, DiffsolError> {
         match Self::try_new_from_indices(nrows, ncols, indices.as_slice()) {
             Ok((sparsity, _)) => Ok(sparsity),
-            Err(e) => Err(anyhow::anyhow!("Failed to create sparsity pattern: {}", e)),
+            Err(e) => Err(DiffsolError::Other(e.to_string())),
         }
     }
 }
@@ -218,13 +219,10 @@ impl<T: Scalar> Matrix for SparseColMat<T> {
         nrows: IndexType,
         ncols: IndexType,
         triplets: Vec<(IndexType, IndexType, T)>,
-    ) -> Result<Self> {
+    ) -> Result<Self, DiffsolError> {
         match faer::sparse::SparseColMat::try_new_from_triplets(nrows, ncols, triplets.as_slice()) {
             Ok(mat) => Ok(Self(mat)),
-            Err(e) => Err(anyhow::anyhow!(
-                "Failed to create matrix from triplets: {}",
-                e
-            )),
+            Err(e) => Err(DiffsolError::from(MatrixError::FailedToCreateMatrixFromTriplets(e))),
         }
     }
     fn gemv(&self, alpha: Self::T, x: &Self::V, beta: Self::T, y: &mut Self::V) {

--- a/src/matrix/sparse_faer.rs
+++ b/src/matrix/sparse_faer.rs
@@ -222,7 +222,9 @@ impl<T: Scalar> Matrix for SparseColMat<T> {
     ) -> Result<Self, DiffsolError> {
         match faer::sparse::SparseColMat::try_new_from_triplets(nrows, ncols, triplets.as_slice()) {
             Ok(mat) => Ok(Self(mat)),
-            Err(e) => Err(DiffsolError::from(MatrixError::FailedToCreateMatrixFromTriplets(e))),
+            Err(e) => Err(DiffsolError::from(
+                MatrixError::FailedToCreateMatrixFromTriplets(e),
+            )),
         }
     }
     fn gemv(&self, alpha: Self::T, x: &Self::V, beta: Self::T, y: &mut Self::V) {

--- a/src/matrix/sparsity.rs
+++ b/src/matrix/sparsity.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::{DiffsolError, MatrixError},
+    matrix_error,
     scalar::IndexType,
     vector::{Vector, VectorIndex},
 };
@@ -62,7 +63,7 @@ where
 {
     fn union(self, other: M::SparsityRef<'_>) -> Result<M::Sparsity, DiffsolError> {
         if self.nrows() != other.nrows() || self.ncols() != other.ncols() {
-            return Err(DiffsolError::from(MatrixError::UnionIncompatibleShapes));
+            return Err(matrix_error!(UnionIncompatibleShapes));
         }
         Ok(Self::new(self.nrows(), self.ncols()))
     }
@@ -89,7 +90,7 @@ where
         _indices: Vec<(IndexType, IndexType)>,
     ) -> Result<Self, DiffsolError> {
         if nrows == 0 || ncols == 0 {
-            return Err(DiffsolError::from(MatrixError::MatrixShapeError));
+            return Err(matrix_error!(MatrixShapeError));
         }
         Ok(Dense::new(nrows, ncols))
     }

--- a/src/matrix/sparsity.rs
+++ b/src/matrix/sparsity.rs
@@ -1,5 +1,7 @@
 use crate::{
-    error::{DiffsolError, MatrixError}, scalar::IndexType, vector::{Vector, VectorIndex}
+    error::{DiffsolError, MatrixError},
+    scalar::IndexType,
+    vector::{Vector, VectorIndex},
 };
 
 use super::Matrix;

--- a/src/matrix/sundials.rs
+++ b/src/matrix/sundials.rs
@@ -11,8 +11,9 @@ use crate::sundials_sys::{
 };
 
 use crate::{
-    ode_solver::sundials::sundials_check, op::NonLinearOp, scalar::scale,
-    vector::sundials::SundialsVector, IndexType, Scale, SundialsLinearSolver, Vector,
+    error::*, matrix_error, ode_solver::sundials::sundials_check, ode_solver_error,
+    op::NonLinearOp, scalar::scale, vector::sundials::SundialsVector, IndexType, Scale,
+    SundialsLinearSolver, Vector,
 };
 
 #[cfg(not(sundials_version_major = "5"))]

--- a/src/matrix/sundials.rs
+++ b/src/matrix/sundials.rs
@@ -23,7 +23,6 @@ use super::{
     sparsity::{Dense, DenseRef},
     Matrix, MatrixCommon,
 };
-use anyhow::anyhow;
 
 #[derive(Debug)]
 pub struct SundialsMatrix {
@@ -324,11 +323,11 @@ impl Matrix for SundialsMatrix {
         nrows: crate::IndexType,
         ncols: crate::IndexType,
         triplets: Vec<(crate::IndexType, crate::IndexType, Self::T)>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self, DiffsolError> {
         let mut m = Self::zeros(nrows, ncols);
         for (i, j, val) in triplets {
             if i >= nrows || j >= ncols {
-                return Err(anyhow!("Index out of bounds"));
+                return Err(matrix_error!(IndexOutOfBounds));
             }
             m[(i, j)] = val;
         }

--- a/src/matrix/sundials.rs
+++ b/src/matrix/sundials.rs
@@ -11,9 +11,8 @@ use crate::sundials_sys::{
 };
 
 use crate::{
-    error::*, matrix_error, ode_solver::sundials::sundials_check, ode_solver_error,
-    op::NonLinearOp, scalar::scale, vector::sundials::SundialsVector, IndexType, Scale,
-    SundialsLinearSolver, Vector,
+    error::*, matrix_error, ode_solver::sundials::sundials_check, op::NonLinearOp, scalar::scale,
+    vector::sundials::SundialsVector, IndexType, Scale, SundialsLinearSolver, Vector,
 };
 
 #[cfg(not(sundials_version_major = "5"))]

--- a/src/nonlinear_solver/mod.rs
+++ b/src/nonlinear_solver/mod.rs
@@ -1,7 +1,5 @@
-use anyhow::Result;
+use crate::{error::DiffsolError, op::Op, solver::SolverProblem};
 use convergence::Convergence;
-
-use crate::{op::Op, solver::SolverProblem};
 
 pub struct NonLinearSolveSolution<V> {
     pub x0: V,
@@ -30,18 +28,19 @@ pub trait NonLinearSolver<C: Op> {
     fn reset_jacobian(&mut self, x: &C::V, t: C::T);
 
     // Solve the problem `F(x, t) = 0` for fixed t, and return the solution `x`.
-    fn solve(&mut self, x: &C::V, t: C::T, error_y: &C::V) -> Result<C::V> {
+    fn solve(&mut self, x: &C::V, t: C::T, error_y: &C::V) -> Result<C::V, DiffsolError> {
         let mut x = x.clone();
         self.solve_in_place(&mut x, t, error_y)?;
         Ok(x)
     }
 
     /// Solve the problem `F(x) = 0` in place.
-    fn solve_in_place(&mut self, x: &mut C::V, t: C::T, error_y: &C::V) -> Result<()>;
+    fn solve_in_place(&mut self, x: &mut C::V, t: C::T, error_y: &C::V)
+        -> Result<(), DiffsolError>;
 
     /// Solve the linearised problem `J * x = b`, where `J` was calculated using [Self::reset_jacobian].
     /// The input `b` is provided in `x`, and the solution is returned in `x`.
-    fn solve_linearised_in_place(&self, x: &mut C::V) -> Result<()>;
+    fn solve_linearised_in_place(&self, x: &mut C::V) -> Result<(), DiffsolError>;
 }
 
 pub mod convergence;

--- a/src/nonlinear_solver/newton.rs
+++ b/src/nonlinear_solver/newton.rs
@@ -88,7 +88,7 @@ impl<C: NonLinearOp, Ls: LinearSolver<C>> NonLinearSolver<C> for NewtonNonlinear
     }
 
     fn solve_linearised_in_place(&self, x: &mut C::V) -> Result<(), DiffsolError> {
-        self.linear_solver.solve_in_place(x).into()
+        self.linear_solver.solve_in_place(x)
     }
 
     fn solve_in_place(

--- a/src/nonlinear_solver/newton.rs
+++ b/src/nonlinear_solver/newton.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::{DiffsolError, NonLinearSolverError},
+    non_linear_solver_error,
     op::NonLinearOp,
     Convergence, ConvergenceStatus, LinearSolver, NonLinearSolver, SolverProblem, Vector,
 };
@@ -31,9 +32,7 @@ pub fn newton_iteration<V: Vector>(
             ConvergenceStatus::MaximumIterations => break,
         }
     }
-    Err(DiffsolError::from(
-        NonLinearSolverError::NewtonDidNotConverge,
-    ))
+    Err(non_linear_solver_error!(NewtonDidNotConverge))
 }
 
 pub struct NewtonNonlinearSolver<C: NonLinearOp, Ls: LinearSolver<C>> {

--- a/src/nonlinear_solver/root.rs
+++ b/src/nonlinear_solver/root.rs
@@ -1,7 +1,9 @@
 use std::cell::RefCell;
 
 use crate::{
-    error::DiffsolError, scalar::{IndexType, Scalar}, NonLinearOp, Vector
+    error::DiffsolError,
+    scalar::{IndexType, Scalar},
+    NonLinearOp, Vector,
 };
 
 use num_traits::{abs, One, Zero};

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -872,7 +872,7 @@ where
         self.tstop = Some(tstop);
         if let Some(OdeSolverStopReason::TstopReached) = self.handle_tstop(tstop)? {
             let error = OdeSolverError::StopTimeBeforeCurrentTime {
-                stop_time: self.tstop.unwrap().into(),
+                stop_time: tstop.into(),
                 state_time: self.state.as_ref().unwrap().t.into(),
             };
             self.tstop = None;

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -2,7 +2,7 @@ use nalgebra::ComplexField;
 use std::rc::Rc;
 use std::{ops::AddAssign, ops::MulAssign, panic};
 
-use anyhow::{anyhow, Result};
+use crate::error::{DiffsolError, OdeSolverError};
 
 use num_traits::{abs, One, Pow, Zero};
 use serde::Serialize;
@@ -322,7 +322,10 @@ where
         t_new
     }
 
-    fn handle_tstop(&mut self, tstop: Eqn::T) -> Result<Option<OdeSolverStopReason<Eqn::T>>> {
+    fn handle_tstop(
+        &mut self,
+        tstop: Eqn::T,
+    ) -> Result<Option<OdeSolverStopReason<Eqn::T>>, DiffsolError> {
         // check if the we are at tstop
         let state = self.state.as_ref().unwrap();
         let troundoff = Eqn::T::from(100.0) * Eqn::T::EPSILON * (abs(state.t) + abs(state.h));
@@ -330,8 +333,13 @@ where
             self.tstop = None;
             return Ok(Some(OdeSolverStopReason::TstopReached));
         } else if tstop < state.t - troundoff {
+            let error = OdeSolverError::StopTimeBeforeCurrentTime {
+                stop_time: self.tstop.unwrap().into(),
+                state_time: state.t.into(),
+            };
             self.tstop = None;
-            return Err(anyhow!("tstop is before current time"));
+
+            return Err(DiffsolError::from(error));
         }
 
         // check if the next step will be beyond tstop, if so adjust the step size
@@ -384,7 +392,11 @@ where
         order_summation
     }
 
-    fn sensitivity_solve(&mut self, t_new: Eqn::T, mut error_norm: Eqn::T) -> Result<Eqn::T> {
+    fn sensitivity_solve(
+        &mut self,
+        t_new: Eqn::T,
+        mut error_norm: Eqn::T,
+    ) -> Result<Eqn::T, DiffsolError> {
         let h = self.state.as_ref().unwrap().h;
 
         // update for new state
@@ -402,8 +414,9 @@ where
         }
 
         // reuse linear solver from nonlinear solver
-        let ls =
-            |x: &mut Eqn::V| -> Result<()> { self.nonlinear_solver.solve_linearised_in_place(x) };
+        let ls = |x: &mut Eqn::V| -> Result<(), DiffsolError> {
+            self.nonlinear_solver.solve_linearised_in_place(x)
+        };
 
         // construct bdf discretisation of sensitivity equations
         let op = self.s_op.as_ref().unwrap();
@@ -471,19 +484,26 @@ where
         self.order
     }
 
-    fn interpolate(&self, t: Eqn::T) -> Result<Eqn::V> {
+    fn interpolate(&self, t: Eqn::T) -> Result<Eqn::V, DiffsolError> {
         // state must be set
-        let state = self.state.as_ref().ok_or(anyhow!("State not set"))?;
+        let state = self
+            .state
+            .as_ref()
+            .ok_or(DiffsolError::from(OdeSolverError::StateNotSet))?;
         if self.is_state_modified {
             if t == state.t {
                 return Ok(state.y.clone());
             } else {
-                return Err(anyhow::anyhow!("Interpolation time is not within the current step. Step size is zero after calling state_mut()"));
+                return Err(DiffsolError::from(
+                    OdeSolverError::InterpolationTimeOutsideCurrentStep,
+                ));
             }
         }
         // check that t is before the current time
         if t > state.t {
-            return Err(anyhow!("Interpolation time is after current time"));
+            return Err(DiffsolError::from(
+                OdeSolverError::InterpolationTimeAfterCurrentTime,
+            ));
         }
 
         Ok(Self::interpolate_from_diff(
@@ -491,19 +511,26 @@ where
         ))
     }
 
-    fn interpolate_sens(&self, t: <Eqn as OdeEquations>::T) -> Result<Vec<Eqn::V>> {
+    fn interpolate_sens(&self, t: <Eqn as OdeEquations>::T) -> Result<Vec<Eqn::V>, DiffsolError> {
         // state must be set
-        let state = self.state.as_ref().ok_or(anyhow!("State not set"))?;
+        let state = self
+            .state
+            .as_ref()
+            .ok_or(DiffsolError::from(OdeSolverError::StateNotSet))?;
         if self.is_state_modified {
             if t == state.t {
                 return Ok(state.s.clone());
             } else {
-                return Err(anyhow::anyhow!("Interpolation time is not within the current step. Step size is zero after calling state_mut()"));
+                return Err(DiffsolError::from(
+                    OdeSolverError::InterpolationTimeOutsideCurrentStep,
+                ));
             }
         }
         // check that t is before the current time
         if t > state.t {
-            return Err(anyhow!("Interpolation time is after current time"));
+            return Err(DiffsolError::from(
+                OdeSolverError::InterpolationTimeAfterCurrentTime,
+            ));
         }
 
         let mut s = Vec::with_capacity(state.s.len());
@@ -594,11 +621,11 @@ where
         self.initialise_to_first_order();
     }
 
-    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>> {
+    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>, DiffsolError> {
         let mut safety: Eqn::T;
         let mut error_norm: Eqn::T;
         if self.state.is_none() {
-            return Err(anyhow!("State not set"));
+            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
         }
 
         self.updated_jacobian = false;
@@ -653,7 +680,8 @@ where
                     error_norm = match self.sensitivity_solve(t_new, error_norm) {
                         Ok(en) => en,
                         Err(_) => {
-                            solve_result = Err(anyhow!("Sensitivity solve failed"));
+                            solve_result =
+                                Err(DiffsolError::from(OdeSolverError::SensitivitySolveFailed));
                             Eqn::T::from(2.0)
                         }
                     }
@@ -706,7 +734,9 @@ where
                 // if step size too small, then fail
                 let state = self.state.as_ref().unwrap();
                 if state.h < Eqn::T::from(Self::MIN_TIMESTEP) {
-                    return Err(anyhow::anyhow!("Step size too small at t = {}", state.t));
+                    return Err(DiffsolError::from(OdeSolverError::StepSizeTooSmall {
+                        time: state.t.into(),
+                    }));
                 }
 
                 // new prediction
@@ -818,7 +848,7 @@ where
         // check for root within accepted step
         if let Some(root_fn) = self.problem().as_ref().unwrap().eqn.root() {
             let ret = self.root_finder.as_ref().unwrap().check_root(
-                &|t| self.interpolate(t),
+                &|t: <Eqn as OdeEquations>::T| self.interpolate(t),
                 root_fn.as_ref(),
                 &self.state.as_ref().unwrap().y,
                 self.state.as_ref().unwrap().t,
@@ -838,14 +868,15 @@ where
         Ok(OdeSolverStopReason::InternalTimestep)
     }
 
-    fn set_stop_time(&mut self, tstop: <Eqn as OdeEquations>::T) -> Result<()> {
+    fn set_stop_time(&mut self, tstop: <Eqn as OdeEquations>::T) -> Result<(), DiffsolError> {
         self.tstop = Some(tstop);
         if let Some(OdeSolverStopReason::TstopReached) = self.handle_tstop(tstop)? {
+            let error = OdeSolverError::StopTimeBeforeCurrentTime {
+                stop_time: self.tstop.unwrap().into(),
+                state_time: self.state.as_ref().unwrap().t.into(),
+            };
             self.tstop = None;
-            return Err(anyhow!(
-                "tstop is at or before current time t = {}",
-                self.state.as_ref().unwrap().t
-            ));
+            return Err(DiffsolError::from(error));
         }
         Ok(())
     }

--- a/src/ode_solver/builder.rs
+++ b/src/ode_solver/builder.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use crate::{
     error::{DiffsolError, OdeSolverError},
+    ode_solver_error,
     vector::DefaultDenseMatrix,
     Closure, ClosureNoJac, ClosureWithSens, ConstantClosure, ConstantClosureWithSens,
     LinearClosure, LinearClosureWithSens, Matrix, OdeEquations, OdeSolverProblem, Op, UnitCallable,
@@ -149,7 +150,7 @@ impl OdeBuilder {
         if atol.len() == 1 {
             Ok(V::from_element(nstates, V::T::from(atol[0])))
         } else if atol.len() != nstates {
-            Err(DiffsolError::from(OdeSolverError::AtolLengthMismatch))
+            Err(ode_solver_error!(AtolLengthMismatch))
         } else {
             let mut v = V::zeros(nstates);
             for (i, &a) in atol.iter().enumerate() {

--- a/src/ode_solver/builder.rs
+++ b/src/ode_solver/builder.rs
@@ -1,7 +1,11 @@
 use std::rc::Rc;
 
 use crate::{
-    error::{DiffsolError, OdeSolverError}, vector::DefaultDenseMatrix, Closure, ClosureNoJac, ClosureWithSens, ConstantClosure, ConstantClosureWithSens, LinearClosure, LinearClosureWithSens, Matrix, OdeEquations, OdeSolverProblem, Op, UnitCallable, Vector
+    error::{DiffsolError, OdeSolverError},
+    vector::DefaultDenseMatrix,
+    Closure, ClosureNoJac, ClosureWithSens, ConstantClosure, ConstantClosureWithSens,
+    LinearClosure, LinearClosureWithSens, Matrix, OdeEquations, OdeSolverProblem, Op, UnitCallable,
+    Vector,
 };
 
 use super::equations::OdeSolverEquations;
@@ -214,7 +218,8 @@ impl OdeBuilder {
     ) -> Result<
         OdeSolverProblem<
             OdeSolverEquations<M, Closure<M, F, G>, ConstantClosure<M, I>, LinearClosure<M, H>>,
-        >, DiffsolError
+        >,
+        DiffsolError,
     >
     where
         M: Matrix,
@@ -271,7 +276,8 @@ impl OdeBuilder {
                 UnitCallable<M>,
                 Closure<M, J, K>,
             >,
-        >, DiffsolError
+        >,
+        DiffsolError,
     >
     where
         M: Matrix,
@@ -379,7 +385,8 @@ impl OdeBuilder {
                 ConstantClosureWithSens<M, I, K>,
                 LinearClosureWithSens<M, H, L>,
             >,
-        >, DiffsolError
+        >,
+        DiffsolError,
     >
     where
         M: Matrix,
@@ -455,7 +462,10 @@ impl OdeBuilder {
         rhs: F,
         rhs_jac: G,
         init: I,
-    ) -> Result<OdeSolverProblem<OdeSolverEquations<M, Closure<M, F, G>, ConstantClosure<M, I>>>, DiffsolError>
+    ) -> Result<
+        OdeSolverProblem<OdeSolverEquations<M, Closure<M, F, G>, ConstantClosure<M, I>>>,
+        DiffsolError,
+    >
     where
         M: Matrix,
         F: Fn(&M::V, &M::V, M::T, &mut M::V),
@@ -527,7 +537,8 @@ impl OdeBuilder {
     ) -> Result<
         OdeSolverProblem<
             OdeSolverEquations<M, ClosureWithSens<M, F, G, J>, ConstantClosureWithSens<M, I, K>>,
-        >, DiffsolError
+        >,
+        DiffsolError,
     >
     where
         M: Matrix,
@@ -615,7 +626,8 @@ impl OdeBuilder {
                 UnitCallable<M>,
                 ClosureNoJac<M, H>,
             >,
-        >, DiffsolError
+        >,
+        DiffsolError,
     >
     where
         M: Matrix,
@@ -657,7 +669,8 @@ impl OdeBuilder {
         rhs_jac: G,
         init: I,
     ) -> Result<
-        OdeSolverProblem<OdeSolverEquations<V::M, Closure<V::M, F, G>, ConstantClosure<V::M, I>>>, DiffsolError
+        OdeSolverProblem<OdeSolverEquations<V::M, Closure<V::M, F, G>, ConstantClosure<V::M, I>>>,
+        DiffsolError,
     >
     where
         V: Vector + DefaultDenseMatrix,

--- a/src/ode_solver/builder.rs
+++ b/src/ode_solver/builder.rs
@@ -688,7 +688,7 @@ impl OdeBuilder {
     pub fn build_diffsl<M>(
         self,
         context: &crate::ode_solver::diffsl::DiffSlContext<M>,
-    ) -> Result<OdeSolverProblem<crate::ode_solver::diffsl::DiffSl<'_, M>>>
+    ) -> Result<OdeSolverProblem<crate::ode_solver::diffsl::DiffSl<'_, M>>, DiffsolError>
     where
         M: Matrix<T = crate::ode_solver::diffsl::T>,
     {

--- a/src/ode_solver/diffsl.rs
+++ b/src/ode_solver/diffsl.rs
@@ -1,6 +1,5 @@
 use std::{cell::RefCell, rc::Rc};
 
-use anyhow::Result;
 use diffsl::execution::Compiler;
 
 use crate::{

--- a/src/ode_solver/diffsl.rs
+++ b/src/ode_solver/diffsl.rs
@@ -57,7 +57,8 @@ impl<M: Matrix<T = T>> DiffSlContext<M> {
     /// Create a new context for the ODE equations specified using the [DiffSL language](https://martinjrobins.github.io/diffsl/).
     /// The input parameters are not initialized and must be set using the [OdeEquations::set_params] function before solving the ODE.
     pub fn new(text: &str) -> Result<Self, DiffsolError> {
-        let compiler = Compiler::from_discrete_str(text)?;
+        let compiler =
+            Compiler::from_discrete_str(text).map_err(|e| DiffsolError::Other(e.to_string()))?;
         let (nstates, nparams, nout, _ndata, nroots) = compiler.get_dims();
         let data = RefCell::new(compiler.get_new_data());
         let ddata = RefCell::new(compiler.get_new_data());
@@ -76,7 +77,8 @@ impl<M: Matrix<T = T>> DiffSlContext<M> {
     }
 
     pub fn recompile(&mut self, text: &str) -> Result<(), DiffsolError> {
-        self.compiler = Compiler::from_discrete_str(text)?;
+        self.compiler =
+            Compiler::from_discrete_str(text).map_err(|e| DiffsolError::Other(e.to_string()))?;
         let (nstates, nparams, nout, _ndata, nroots) = self.compiler.get_dims();
         self.data = RefCell::new(self.compiler.get_new_data());
         self.ddata = RefCell::new(self.compiler.get_new_data());

--- a/src/ode_solver/diffsl.rs
+++ b/src/ode_solver/diffsl.rs
@@ -3,6 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use diffsl::execution::Compiler;
 
 use crate::{
+    error::DiffsolError,
     jacobian::{find_non_zeros_linear, find_non_zeros_nonlinear, JacobianColoring},
     matrix::sparsity::MatrixSparsity,
     op::{LinearOp, NonLinearOp, Op},
@@ -55,7 +56,7 @@ pub struct DiffSlContext<M: Matrix<T = T>> {
 impl<M: Matrix<T = T>> DiffSlContext<M> {
     /// Create a new context for the ODE equations specified using the [DiffSL language](https://martinjrobins.github.io/diffsl/).
     /// The input parameters are not initialized and must be set using the [OdeEquations::set_params] function before solving the ODE.
-    pub fn new(text: &str) -> Result<Self> {
+    pub fn new(text: &str) -> Result<Self, DiffsolError> {
         let compiler = Compiler::from_discrete_str(text)?;
         let (nstates, nparams, nout, _ndata, nroots) = compiler.get_dims();
         let data = RefCell::new(compiler.get_new_data());
@@ -74,7 +75,7 @@ impl<M: Matrix<T = T>> DiffSlContext<M> {
         })
     }
 
-    pub fn recompile(&mut self, text: &str) -> Result<()> {
+    pub fn recompile(&mut self, text: &str) -> Result<(), DiffsolError> {
         self.compiler = Compiler::from_discrete_str(text)?;
         let (nstates, nparams, nout, _ndata, nroots) = self.compiler.get_dims();
         self.data = RefCell::new(self.compiler.get_new_data());

--- a/src/ode_solver/method.rs
+++ b/src/ode_solver/method.rs
@@ -1,12 +1,11 @@
-use anyhow::Result;
 use nalgebra::ComplexField;
 use num_traits::{One, Pow};
 use std::rc::Rc;
 
 use crate::{
-    matrix::default_solver::DefaultSolver, scalar::Scalar, scale, ConstantOp, InitOp,
-    NewtonNonlinearSolver, NonLinearOp, NonLinearSolver, OdeEquations, OdeSolverProblem, Op,
-    SensEquations, SolverProblem, Vector,
+    error::{DiffsolError, OdeSolverError}, matrix::default_solver::DefaultSolver, scalar::Scalar, scale, ConstantOp,
+    InitOp, NewtonNonlinearSolver, NonLinearOp, NonLinearSolver, OdeEquations, OdeSolverProblem,
+    Op, SensEquations, SolverProblem, Vector,
 };
 
 #[derive(Debug, PartialEq)]
@@ -53,17 +52,17 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
     /// - `InternalTimestep`: The solver has taken a step forward in time, the internal state of the solver is at time self.state().t
     /// - `RootFound(t_root)`: The solver has found a root at time `t_root`. Note that the internal state of the solver is at the internal time step `self.state().t`, *not* at time `t_root`.
     /// - `TstopReached`: The solver has reached the stop time set by [Self::set_stop_time], the internal state of the solver is at time `tstop`, which is the same as `self.state().t`
-    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>>;
+    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>, DiffsolError>;
 
     /// Set a stop time for the solver. The solver will stop when the internal time reaches this time.
     /// Once it stops, the stop time is unset. If `tstop` is at or before the current internal time, an error is returned.
-    fn set_stop_time(&mut self, tstop: Eqn::T) -> Result<()>;
+    fn set_stop_time(&mut self, tstop: Eqn::T) -> Result<(), DiffsolError>;
 
     /// Interpolate the solution at a given time. This time should be between the current time and the last solver time step
-    fn interpolate(&self, t: Eqn::T) -> Result<Eqn::V>;
+    fn interpolate(&self, t: Eqn::T) -> Result<Eqn::V, DiffsolError>;
 
     /// Interpolate the sensitivity vectors at a given time. This time should be between the current time and the last solver time step
-    fn interpolate_sens(&self, t: Eqn::T) -> Result<Vec<Eqn::V>>;
+    fn interpolate_sens(&self, t: Eqn::T) -> Result<Vec<Eqn::V>, DiffsolError>;
 
     /// Get the current state of the solver, if it exists
     fn state(&self) -> Option<&OdeSolverState<Eqn::V>>;
@@ -89,7 +88,7 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
         &mut self,
         problem: &OdeSolverProblem<Eqn>,
         final_time: Eqn::T,
-    ) -> Result<(Vec<Eqn::V>, Vec<Eqn::T>)>
+    ) -> Result<(Vec<Eqn::V>, Vec<Eqn::T>), DiffsolError>
     where
         Eqn::M: DefaultSolver,
         Self: Sized,
@@ -120,7 +119,7 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
         &mut self,
         problem: &OdeSolverProblem<Eqn>,
         t_eval: &[Eqn::T],
-    ) -> Result<Vec<Eqn::V>>
+    ) -> Result<Vec<Eqn::V>, DiffsolError>
     where
         Eqn::M: DefaultSolver,
         Self: Sized,
@@ -132,7 +131,7 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
         // check t_eval is increasing and all values are greater than or equal to the current time
         let t0 = self.state().unwrap().t;
         if t_eval.windows(2).any(|w| w[0] > w[1] || w[0] < t0) {
-            return Err(anyhow::anyhow!("t_eval must be increasing and all values must be greater than or equal to the current time"));
+            return Err(DiffsolError::from(OdeSolverError::InvalidTEval));
         }
 
         // do loop
@@ -185,7 +184,7 @@ impl<V: Vector> OdeSolverState<V> {
     /// It will also set the initial step size based on the given solver.
     /// If you want to create a state without this default initialisation, use [Self::new_without_initialise] instead.
     /// You can then use [Self::set_consistent] and [Self::set_step_size] to set the state up if you need to.
-    pub fn new<Eqn, S>(ode_problem: &OdeSolverProblem<Eqn>, solver: &S) -> Result<Self>
+    pub fn new<Eqn, S>(ode_problem: &OdeSolverProblem<Eqn>, solver: &S) -> Result<Self, DiffsolError>
     where
         Eqn: OdeEquations<T = V::T, V = V>,
         Eqn::M: DefaultSolver,
@@ -239,7 +238,7 @@ impl<V: Vector> OdeSolverState<V> {
         &mut self,
         ode_problem: &OdeSolverProblem<Eqn>,
         root_solver: &mut S,
-    ) -> Result<()>
+    ) -> Result<(), DiffsolError>
     where
         Eqn: OdeEquations<T = V::T, V = V>,
         S: NonLinearSolver<InitOp<Eqn>> + ?Sized,
@@ -271,7 +270,7 @@ impl<V: Vector> OdeSolverState<V> {
         &mut self,
         ode_problem: &OdeSolverProblem<Eqn>,
         root_solver: &mut S,
-    ) -> Result<()>
+    ) -> Result<(), DiffsolError>
     where
         Eqn: OdeEquations<T = V::T, V = V>,
         S: NonLinearSolver<InitOp<SensEquations<Eqn>>> + ?Sized,

--- a/src/ode_solver/method.rs
+++ b/src/ode_solver/method.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use crate::{
     error::{DiffsolError, OdeSolverError},
     matrix::default_solver::DefaultSolver,
+    ode_solver_error,
     scalar::Scalar,
     scale, ConstantOp, InitOp, NewtonNonlinearSolver, NonLinearOp, NonLinearSolver, OdeEquations,
     OdeSolverProblem, Op, SensEquations, SolverProblem, Vector,
@@ -141,7 +142,7 @@ pub trait OdeSolverMethod<Eqn: OdeEquations> {
         // check t_eval is increasing and all values are greater than or equal to the current time
         let t0 = self.state().unwrap().t;
         if t_eval.windows(2).any(|w| w[0] > w[1] || w[0] < t0) {
-            return Err(DiffsolError::from(OdeSolverError::InvalidTEval));
+            return Err(ode_solver_error!(InvalidTEval));
         }
 
         // do loop

--- a/src/ode_solver/method.rs
+++ b/src/ode_solver/method.rs
@@ -3,9 +3,11 @@ use num_traits::{One, Pow};
 use std::rc::Rc;
 
 use crate::{
-    error::{DiffsolError, OdeSolverError}, matrix::default_solver::DefaultSolver, scalar::Scalar, scale, ConstantOp,
-    InitOp, NewtonNonlinearSolver, NonLinearOp, NonLinearSolver, OdeEquations, OdeSolverProblem,
-    Op, SensEquations, SolverProblem, Vector,
+    error::{DiffsolError, OdeSolverError},
+    matrix::default_solver::DefaultSolver,
+    scalar::Scalar,
+    scale, ConstantOp, InitOp, NewtonNonlinearSolver, NonLinearOp, NonLinearSolver, OdeEquations,
+    OdeSolverProblem, Op, SensEquations, SolverProblem, Vector,
 };
 
 #[derive(Debug, PartialEq)]
@@ -184,7 +186,10 @@ impl<V: Vector> OdeSolverState<V> {
     /// It will also set the initial step size based on the given solver.
     /// If you want to create a state without this default initialisation, use [Self::new_without_initialise] instead.
     /// You can then use [Self::set_consistent] and [Self::set_step_size] to set the state up if you need to.
-    pub fn new<Eqn, S>(ode_problem: &OdeSolverProblem<Eqn>, solver: &S) -> Result<Self, DiffsolError>
+    pub fn new<Eqn, S>(
+        ode_problem: &OdeSolverProblem<Eqn>,
+        solver: &S,
+    ) -> Result<Self, DiffsolError>
     where
         Eqn: OdeEquations<T = V::T, V = V>,
         Eqn::M: DefaultSolver,

--- a/src/ode_solver/problem.rs
+++ b/src/ode_solver/problem.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use crate::{
     error::{DiffsolError, OdeSolverError},
+    ode_solver_error,
     vector::Vector,
     ConstantOp, LinearOp, NonLinearOp, OdeEquations, SensEquations,
 };
@@ -56,7 +57,7 @@ impl<Eqn: OdeEquations> OdeSolverProblem<Eqn> {
         };
         let eqn_has_sens = eqn.rhs().has_sens() && eqn.init().has_sens() && mass_has_sens;
         if with_sensitivity && !eqn_has_sens {
-            return Err(DiffsolError::from(OdeSolverError::SensitivityNotSupported));
+            return Err(ode_solver_error!(SensitivityNotSupported));
         }
         let eqn_sens = if with_sensitivity {
             Some(Rc::new(SensEquations::new(&eqn)))
@@ -75,9 +76,8 @@ impl<Eqn: OdeEquations> OdeSolverProblem<Eqn> {
     }
 
     pub fn set_params(&mut self, p: Eqn::V) -> Result<(), DiffsolError> {
-        let eqn = Rc::get_mut(&mut self.eqn).ok_or(DiffsolError::from(
-            OdeSolverError::FailedToGetMutableReference,
-        ))?;
+        let eqn =
+            Rc::get_mut(&mut self.eqn).ok_or(ode_solver_error!(FailedToGetMutableReference))?;
         eqn.set_params(p);
         Ok(())
     }

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -9,6 +9,7 @@ use crate::error::DiffsolError;
 use crate::error::OdeSolverError;
 use crate::matrix::MatrixRef;
 use crate::nonlinear_solver::newton::newton_iteration;
+use crate::ode_solver_error;
 use crate::vector::VectorRef;
 use crate::LinearSolver;
 use crate::NewtonNonlinearSolver;
@@ -373,7 +374,7 @@ where
 
     fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>, DiffsolError> {
         if self.state.is_none() {
-            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
+            return Err(ode_solver_error!(StateNotSet));
         }
         let n = self.state.as_ref().unwrap().y.len();
 
@@ -634,7 +635,7 @@ where
         t: <Eqn as OdeEquations>::T,
     ) -> Result<Vec<<Eqn as OdeEquations>::V>, DiffsolError> {
         if self.state.is_none() {
-            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
+            return Err(ode_solver_error!(StateNotSet));
         }
         let state = self.state.as_ref().unwrap();
 
@@ -642,17 +643,13 @@ where
             if t == state.t {
                 return Ok(state.s.clone());
             } else {
-                return Err(DiffsolError::from(
-                    OdeSolverError::InterpolationTimeOutsideCurrentStep,
-                ));
+                return Err(ode_solver_error!(InterpolationTimeOutsideCurrentStep));
             }
         }
 
         // check that t is within the current step
         if t > state.t || t < self.old_t {
-            return Err(DiffsolError::from(
-                OdeSolverError::InterpolationTimeOutsideCurrentStep,
-            ));
+            return Err(ode_solver_error!(InterpolationTimeOutsideCurrentStep));
         }
         let dt = state.t - self.old_t;
         let theta = if dt == Eqn::T::zero() {
@@ -684,7 +681,7 @@ where
 
     fn interpolate(&self, t: <Eqn>::T) -> Result<<Eqn>::V, DiffsolError> {
         if self.state.is_none() {
-            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
+            return Err(ode_solver_error!(StateNotSet));
         }
         let state = self.state.as_ref().unwrap();
 
@@ -692,17 +689,13 @@ where
             if t == state.t {
                 return Ok(state.y.clone());
             } else {
-                return Err(DiffsolError::from(
-                    OdeSolverError::InterpolationTimeOutsideCurrentStep,
-                ));
+                return Err(ode_solver_error!(InterpolationTimeOutsideCurrentStep));
             }
         }
 
         // check that t is within the current step
         if t > state.t || t < self.old_t {
-            return Err(DiffsolError::from(
-                OdeSolverError::InterpolationTimeOutsideCurrentStep,
-            ));
+            return Err(ode_solver_error!(InterpolationTimeOutsideCurrentStep));
         }
         let dt = state.t - self.old_t;
         let theta = if dt == Eqn::T::zero() {

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -260,13 +260,9 @@ where
             // solve
             {
                 let result =
-                    newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence)
-                        .map_err(|e| DiffsolError::from(e));
-                match result {
-                    Err(e) => {
-                        return Err(e);
-                    }
-                    Ok(_) => {}
+                    newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence);
+                if let Err(e) = result {
+                    return Err(e);
                 }
                 self.old_y_sens[j].copy_from(&op.get_last_f_eval());
                 self.statistics.number_of_nonlinear_solver_iterations += convergence.niter();

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -258,8 +258,9 @@ where
 
             // solve
             {
-                let result = newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence)
-                    .map_err(|e| DiffsolError::from(e));
+                let result =
+                    newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence)
+                        .map_err(|e| DiffsolError::from(e));
                 match result {
                     Err(e) => {
                         return Err(e);

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -259,11 +259,7 @@ where
 
             // solve
             {
-                let result =
-                    newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence);
-                if let Err(e) = result {
-                    return Err(e);
-                }
+                newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence)?;
                 self.old_y_sens[j].copy_from(&op.get_last_f_eval());
                 self.statistics.number_of_nonlinear_solver_iterations += convergence.niter();
             }

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -1,5 +1,3 @@
-use anyhow::anyhow;
-use anyhow::Result;
 use num_traits::abs;
 use num_traits::One;
 use num_traits::Pow;
@@ -7,6 +5,8 @@ use num_traits::Zero;
 use std::ops::MulAssign;
 use std::rc::Rc;
 
+use crate::error::DiffsolError;
+use crate::error::OdeSolverError;
 use crate::matrix::MatrixRef;
 use crate::nonlinear_solver::newton::newton_iteration;
 use crate::vector::VectorRef;
@@ -180,7 +180,10 @@ where
         &self.statistics
     }
 
-    fn handle_tstop(&mut self, tstop: Eqn::T) -> Result<Option<OdeSolverStopReason<Eqn::T>>> {
+    fn handle_tstop(
+        &mut self,
+        tstop: Eqn::T,
+    ) -> Result<Option<OdeSolverStopReason<Eqn::T>>, DiffsolError> {
         let state = self.state.as_mut().unwrap();
 
         // check if the we are at tstop
@@ -189,10 +192,11 @@ where
             self.tstop = None;
             return Ok(Some(OdeSolverStopReason::TstopReached));
         } else if tstop < state.t - troundoff {
-            return Err(anyhow::anyhow!(
-                "tstop = {} is less than current time t = {}",
-                tstop,
-                state.t
+            return Err(DiffsolError::from(
+                OdeSolverError::StopTimeBeforeCurrentTime {
+                    stop_time: tstop.into(),
+                    state_time: state.t.into(),
+                },
             ));
         }
 
@@ -219,7 +223,7 @@ where
         }
     }
 
-    fn solve_for_sensitivities(&mut self, i: usize, t: Eqn::T) -> Result<()> {
+    fn solve_for_sensitivities(&mut self, i: usize, t: Eqn::T) -> Result<(), DiffsolError> {
         // update for new state
         {
             self.problem()
@@ -233,8 +237,9 @@ where
         }
 
         // reuse linear solver from nonlinear solver
-        let ls =
-            |x: &mut Eqn::V| -> Result<()> { self.nonlinear_solver.solve_linearised_in_place(x) };
+        let ls = |x: &mut Eqn::V| -> Result<(), DiffsolError> {
+            self.nonlinear_solver.solve_linearised_in_place(x)
+        };
 
         // construct bdf discretisation of sensitivity equations
         let op = self.s_op.as_ref().unwrap();
@@ -253,7 +258,14 @@ where
 
             // solve
             {
-                newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence)?;
+                let result = newton_iteration(ds, &mut self.old_y_sens[j], s0, fun, ls, &mut convergence)
+                    .map_err(|e| DiffsolError::from(e));
+                match result {
+                    Err(e) => {
+                        return Err(e);
+                    }
+                    Ok(_) => {}
+                }
                 self.old_y_sens[j].copy_from(&op.get_last_f_eval());
                 self.statistics.number_of_nonlinear_solver_iterations += convergence.niter();
             }
@@ -358,9 +370,9 @@ where
         }
     }
 
-    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>> {
+    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>, DiffsolError> {
         if self.state.is_none() {
-            return Err(anyhow!("State not set"));
+            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
         }
         let n = self.state.as_ref().unwrap().y.len();
 
@@ -453,7 +465,9 @@ where
 
                         // if step size too small, then fail
                         if state.h < Eqn::T::from(Self::MIN_TIMESTEP) {
-                            return Err(anyhow::anyhow!("Step size too small at t = {}", state.t));
+                            return Err(DiffsolError::from(OdeSolverError::StepSizeTooSmall {
+                                time: state.t.into(),
+                            }));
                         }
 
                         // update h for new step size
@@ -525,7 +539,9 @@ where
 
             // if step size too small, then fail
             if state.h < Eqn::T::from(Self::MIN_TIMESTEP) {
-                return Err(anyhow::anyhow!("Step size too small at t = {}", state.t));
+                return Err(DiffsolError::from(OdeSolverError::StepSizeTooSmall {
+                    time: state.t.into(),
+                }));
             }
 
             // test error is within tolerance
@@ -599,14 +615,15 @@ where
         Ok(OdeSolverStopReason::InternalTimestep)
     }
 
-    fn set_stop_time(&mut self, tstop: <Eqn as OdeEquations>::T) -> Result<()> {
+    fn set_stop_time(&mut self, tstop: <Eqn as OdeEquations>::T) -> Result<(), DiffsolError> {
         self.tstop = Some(tstop);
         if let Some(OdeSolverStopReason::TstopReached) = self.handle_tstop(tstop)? {
+            let error = OdeSolverError::StopTimeBeforeCurrentTime {
+                stop_time: tstop.into(),
+                state_time: self.state.as_ref().unwrap().t.into(),
+            };
             self.tstop = None;
-            return Err(anyhow::anyhow!(
-                "Stop time is at or before current time t = {}",
-                self.state.as_ref().unwrap().t
-            ));
+            return Err(DiffsolError::from(error));
         }
         Ok(())
     }
@@ -614,9 +631,9 @@ where
     fn interpolate_sens(
         &self,
         t: <Eqn as OdeEquations>::T,
-    ) -> Result<Vec<<Eqn as OdeEquations>::V>> {
+    ) -> Result<Vec<<Eqn as OdeEquations>::V>, DiffsolError> {
         if self.state.is_none() {
-            return Err(anyhow!("State not set"));
+            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
         }
         let state = self.state.as_ref().unwrap();
 
@@ -624,14 +641,16 @@ where
             if t == state.t {
                 return Ok(state.s.clone());
             } else {
-                return Err(anyhow::anyhow!("Interpolation time is not within the current step. Step size is zero after calling state_mut()"));
+                return Err(DiffsolError::from(
+                    OdeSolverError::InterpolationTimeOutsideCurrentStep,
+                ));
             }
         }
 
         // check that t is within the current step
         if t > state.t || t < self.old_t {
-            return Err(anyhow::anyhow!(
-                "Interpolation time is not within the current step"
+            return Err(DiffsolError::from(
+                OdeSolverError::InterpolationTimeOutsideCurrentStep,
             ));
         }
         let dt = state.t - self.old_t;
@@ -662,9 +681,9 @@ where
         }
     }
 
-    fn interpolate(&self, t: <Eqn>::T) -> anyhow::Result<<Eqn>::V> {
+    fn interpolate(&self, t: <Eqn>::T) -> Result<<Eqn>::V, DiffsolError> {
         if self.state.is_none() {
-            return Err(anyhow!("State not set"));
+            return Err(DiffsolError::from(OdeSolverError::StateNotSet));
         }
         let state = self.state.as_ref().unwrap();
 
@@ -672,14 +691,16 @@ where
             if t == state.t {
                 return Ok(state.y.clone());
             } else {
-                return Err(anyhow::anyhow!("Interpolation time is not within the current step. Step size is zero after calling state_mut()"));
+                return Err(DiffsolError::from(
+                    OdeSolverError::InterpolationTimeOutsideCurrentStep,
+                ));
             }
         }
 
         // check that t is within the current step
         if t > state.t || t < self.old_t {
-            return Err(anyhow::anyhow!(
-                "Interpolation time is not within the current step"
+            return Err(DiffsolError::from(
+                OdeSolverError::InterpolationTimeOutsideCurrentStep,
             ));
         }
         let dt = state.t - self.old_t;

--- a/src/ode_solver/sundials.rs
+++ b/src/ode_solver/sundials.rs
@@ -16,8 +16,8 @@ use std::{
 };
 
 use crate::{
-    error::*, matrix::sparsity::MatrixSparsityRef, ode_solver_error, other_error, scale, LinearOp,
-    Matrix, NonLinearOp, OdeEquations, OdeSolverMethod, OdeSolverProblem, OdeSolverState,
+    error::*, matrix::sparsity::MatrixSparsityRef, ode_solver_error, scale, LinearOp, Matrix,
+    NonLinearOp, OdeEquations, OdeSolverMethod, OdeSolverProblem, OdeSolverState,
     OdeSolverStopReason, Op, SundialsMatrix, SundialsVector, Vector,
 };
 
@@ -408,20 +408,20 @@ where
             IDA_SUCCESS => Ok(OdeSolverStopReason::InternalTimestep),
             IDA_TSTOP_RETURN => Ok(OdeSolverStopReason::TstopReached),
             IDA_ROOT_RETURN => Ok(OdeSolverStopReason::RootFound(state.t)),
-            IDA_MEM_NULL => Err(other_error!("The ida_mem argument was NULL.")),
-            IDA_ILL_INPUT => Err(other_error!("One of the inputs to IDASolve() was illegal, or some other input to the solver was either illegal or missing.")),
-            IDA_TOO_MUCH_WORK => Err(other_error!("The solver took mxstep internal steps but could not reach tout.")),
-            IDA_TOO_MUCH_ACC => Err(other_error!("The solver could not satisfy the accuracy demanded by the user for some internal step.")),
-            IDA_ERR_FAIL => Err(other_error!("Error test failures occurred too many times (MXNEF = 10) during one internal time step or occurred with.")),
-            IDA_CONV_FAIL => Err(other_error!("Convergence test failures occurred too many times (MXNCF = 10) during one internal time step or occurred with.")),
-            IDA_LINIT_FAIL => Err(other_error!("The linear solver’s initialization function failed.")),
-            IDA_LSETUP_FAIL => Err(other_error!("The linear solver’s setup function failed in an unrecoverable manner.")),
-            IDA_LSOLVE_FAIL => Err(other_error!("The linear solver’s solve function failed in an unrecoverable manner.")),
-            IDA_CONSTR_FAIL => Err(other_error!("The inequality constraints were violated and the solver was unable to recover.")),
-            IDA_REP_RES_ERR => Err(other_error!("The user’s residual function repeatedly returned a recoverable error flag, but the solver was unable to recover.")),
-            IDA_RES_FAIL => Err(other_error!("The user’s residual function returned a nonrecoverable error flag.")),
-            IDA_RTFUNC_FAIL => Err(other_error!("The rootfinding function failed.")),
-            _ => Err(other_error!("Unknown error")),
+            IDA_MEM_NULL => Err(ode_solver_error!(SundialsError, "The ida_mem argument was NULL.")),
+            IDA_ILL_INPUT => Err(ode_solver_error!(SundialsError, "One of the inputs to IDASolve() was illegal, or some other input to the solver was either illegal or missing.")),
+            IDA_TOO_MUCH_WORK => Err(ode_solver_error!(SundialsError, "The solver took mxstep internal steps but could not reach tout.")),
+            IDA_TOO_MUCH_ACC => Err(ode_solver_error!(SundialsError, "The solver could not satisfy the accuracy demanded by the user for some internal step.")),
+            IDA_ERR_FAIL => Err(ode_solver_error!(SundialsError, "Error test failures occurred too many times (MXNEF = 10) during one internal time step or occurred with.")),
+            IDA_CONV_FAIL => Err(ode_solver_error!(SundialsError, "Convergence test failures occurred too many times (MXNCF = 10) during one internal time step or occurred with.")),
+            IDA_LINIT_FAIL => Err(ode_solver_error!(SundialsError, "The linear solver’s initialization function failed.")),
+            IDA_LSETUP_FAIL => Err(ode_solver_error!(SundialsError, "The linear solver’s setup function failed in an unrecoverable manner.")),
+            IDA_LSOLVE_FAIL => Err(ode_solver_error!(SundialsError, "The linear solver’s solve function failed in an unrecoverable manner.")),
+            IDA_CONSTR_FAIL => Err(ode_solver_error!(SundialsError, "The inequality constraints were violated and the solver was unable to recover.")),
+            IDA_REP_RES_ERR => Err(ode_solver_error!(SundialsError, "The user’s residual function repeatedly returned a recoverable error flag, but the solver was unable to recover.")),
+            IDA_RES_FAIL => Err(ode_solver_error!(SundialsError, "The user’s residual function returned a nonrecoverable error flag.")),
+            IDA_RTFUNC_FAIL => Err(ode_solver_error!(SundialsError, "The rootfinding function failed.")),
+            _ => Err(ode_solver_error!(SundialsError, "Unknown error")),
         }
     }
 

--- a/src/ode_solver/sundials.rs
+++ b/src/ode_solver/sundials.rs
@@ -28,7 +28,9 @@ pub fn sundials_check(retval: c_int) -> Result<()> {
     if retval < 0 {
         let char_ptr = unsafe { IDAGetReturnFlagName(i64::from(retval)) };
         let c_str = unsafe { CStr::from_ptr(char_ptr) };
-        Err(ode_solver_error!(SundialsError(c_str.to_str().unwrap().to_string())))
+        Err(ode_solver_error!(SundialsError(
+            c_str.to_str().unwrap().to_string()
+        )))
     } else {
         Ok(())
     }

--- a/src/ode_solver/sundials.rs
+++ b/src/ode_solver/sundials.rs
@@ -8,7 +8,6 @@ use crate::sundials_sys::{
     IDA_RTFUNC_FAIL, IDA_SUCCESS, IDA_TOO_MUCH_ACC, IDA_TOO_MUCH_WORK, IDA_TSTOP_RETURN,
     IDA_YA_YDP_INIT,
 };
-use anyhow::{anyhow, Result};
 use num_traits::Zero;
 use serde::Serialize;
 use std::{
@@ -29,7 +28,7 @@ pub fn sundials_check(retval: c_int) -> Result<()> {
     if retval < 0 {
         let char_ptr = unsafe { IDAGetReturnFlagName(i64::from(retval)) };
         let c_str = unsafe { CStr::from_ptr(char_ptr) };
-        Err(anyhow!("Sundials Error Name: {}", c_str.to_str()?))
+        Err(ode_solver_error!(SundialsError(c_str.to_str().unwrap().to_string())))
     } else {
         Ok(())
     }
@@ -225,9 +224,9 @@ where
         &self.statistics
     }
 
-    pub fn calc_ic(&mut self, t: realtype) -> Result<()> {
+    pub fn calc_ic(&mut self, t: realtype) -> Result<(), DiffsolError> {
         if self.problem.is_none() {
-            return Err(anyhow!("Problem not set"));
+            return Err(ode_solver_error!(ProblemNotSet));
         }
         if self.problem.as_ref().unwrap().eqn.mass().is_none() {
             return Ok(());
@@ -371,10 +370,10 @@ where
         Self::check(unsafe { IDASetStopTime(self.ida_mem, tstop) })
     }
 
-    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>> {
-        let state = self.state.as_mut().ok_or(anyhow!("State not set"))?;
+    fn step(&mut self) -> Result<OdeSolverStopReason<Eqn::T>, DiffsolError> {
+        let state = self.state.as_mut().ok_or(ode_solver_error!(StateNotSet))?;
         if self.problem.is_none() {
-            return Err(anyhow!("Problem not set"));
+            return Err(ode_solver_error!(ProblemNotSet));
         }
         if self.is_state_modified {
             // reinit as state has been modified
@@ -407,30 +406,30 @@ where
             IDA_SUCCESS => Ok(OdeSolverStopReason::InternalTimestep),
             IDA_TSTOP_RETURN => Ok(OdeSolverStopReason::TstopReached),
             IDA_ROOT_RETURN => Ok(OdeSolverStopReason::RootFound(state.t)),
-            IDA_MEM_NULL => Err(anyhow!("The ida_mem argument was NULL.")),
-            IDA_ILL_INPUT => Err(anyhow!("One of the inputs to IDASolve() was illegal, or some other input to the solver was either illegal or missing.")),
-            IDA_TOO_MUCH_WORK => Err(anyhow!("The solver took mxstep internal steps but could not reach tout.")),
-            IDA_TOO_MUCH_ACC => Err(anyhow!("The solver could not satisfy the accuracy demanded by the user for some internal step.")),
-            IDA_ERR_FAIL => Err(anyhow!("Error test failures occurred too many times (MXNEF = 10) during one internal time step or occurred with.")),
-            IDA_CONV_FAIL => Err(anyhow!("Convergence test failures occurred too many times (MXNCF = 10) during one internal time step or occurred with.")),
-            IDA_LINIT_FAIL => Err(anyhow!("The linear solver’s initialization function failed.")),
-            IDA_LSETUP_FAIL => Err(anyhow!("The linear solver’s setup function failed in an unrecoverable manner.")),
-            IDA_LSOLVE_FAIL => Err(anyhow!("The linear solver’s solve function failed in an unrecoverable manner.")),
-            IDA_CONSTR_FAIL => Err(anyhow!("The inequality constraints were violated and the solver was unable to recover.")),
-            IDA_REP_RES_ERR => Err(anyhow!("The user’s residual function repeatedly returned a recoverable error flag, but the solver was unable to recover.")),
-            IDA_RES_FAIL => Err(anyhow!("The user’s residual function returned a nonrecoverable error flag.")),
-            IDA_RTFUNC_FAIL => Err(anyhow!("The rootfinding function failed.")),
-            _ => Err(anyhow!("Unknown error")),
+            IDA_MEM_NULL => Err(other_error!("The ida_mem argument was NULL.")),
+            IDA_ILL_INPUT => Err(other_error!("One of the inputs to IDASolve() was illegal, or some other input to the solver was either illegal or missing.")),
+            IDA_TOO_MUCH_WORK => Err(other_error!("The solver took mxstep internal steps but could not reach tout.")),
+            IDA_TOO_MUCH_ACC => Err(other_error!("The solver could not satisfy the accuracy demanded by the user for some internal step.")),
+            IDA_ERR_FAIL => Err(other_error!("Error test failures occurred too many times (MXNEF = 10) during one internal time step or occurred with.")),
+            IDA_CONV_FAIL => Err(other_error!("Convergence test failures occurred too many times (MXNCF = 10) during one internal time step or occurred with.")),
+            IDA_LINIT_FAIL => Err(other_error!("The linear solver’s initialization function failed.")),
+            IDA_LSETUP_FAIL => Err(other_error!("The linear solver’s setup function failed in an unrecoverable manner.")),
+            IDA_LSOLVE_FAIL => Err(other_error!("The linear solver’s solve function failed in an unrecoverable manner.")),
+            IDA_CONSTR_FAIL => Err(other_error!("The inequality constraints were violated and the solver was unable to recover.")),
+            IDA_REP_RES_ERR => Err(other_error!("The user’s residual function repeatedly returned a recoverable error flag, but the solver was unable to recover.")),
+            IDA_RES_FAIL => Err(other_error!("The user’s residual function returned a nonrecoverable error flag.")),
+            IDA_RTFUNC_FAIL => Err(other_error!("The rootfinding function failed.")),
+            _ => Err(other_error!("Unknown error")),
         }
     }
 
-    fn interpolate(&self, t: <Eqn>::T) -> Result<Eqn::V> {
+    fn interpolate(&self, t: <Eqn>::T) -> Result<Eqn::V, DiffsolError> {
         if self.data.is_none() {
-            return Err(anyhow!("Problem not set"));
+            return Err(ode_solver_error!(ProblemNotSet));
         }
-        let state = self.state.as_ref().ok_or(anyhow!("State not set"))?;
+        let state = self.state.as_ref().ok_or(ode_solver_error!(StateNotSet))?;
         if t > state.t {
-            return Err(anyhow!("Interpolation time is greater than current time"));
+            return Err(ode_solver_error!(InterpolationTimeGreaterThanCurrentTime));
         }
         let ret = SundialsVector::new_serial(self.data.as_ref().unwrap().eqn.rhs().nstates());
         Self::check(unsafe { IDAGetDky(self.ida_mem, t, 0, ret.sundials_vector()) }).unwrap();


### PR DESCRIPTION
This PR migrates `diffsol` from `anyhow` to `thiserror`. This allows for matchable errors for third-party users.