### PR TITLE
refactor: remove use of Rc in OdeEquations trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ nalgebra = []
 sundials = ["suitesparse_sys", "bindgen", "cc"]
 suitesparse = ["suitesparse_sys"]
 diffsl-cranelift = ["diffsl-no-llvm", "diffsl"]
-diffsl = []
+diffsl = [ ]
 diffsl-llvm = []
 diffsl-llvm13 = ["diffsl13-0", "diffsl-llvm", "diffsl"]
 diffsl-llvm14 = ["diffsl14-0", "diffsl-llvm", "diffsl"]
@@ -29,7 +29,6 @@ diffsl-llvm17 = ["diffsl17-0", "diffsl-llvm", "diffsl"]
 nalgebra = "0.33"
 nalgebra-sparse = { version = "0.10", features = ["io"] }
 num-traits = "0.2.17"
-ouroboros = "0.18.2"
 serde = { version = "1.0.196", features = ["derive"] }
 diffsl-no-llvm = { package = "diffsl", version = "=0.2.0", optional = true }
 diffsl13-0 = { package = "diffsl", version = "=0.2.0", features = ["llvm13-0"], optional = true }

--- a/benches/ode_solvers.rs
+++ b/benches/ode_solvers.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use diffsol::{
     ode_solver::test_models::{
         exponential_decay::exponential_decay_problem, foodweb::foodweb_problem,
-        foodweb::FoodWebContext, heat2d::head2d_problem, robertson::robertson,
+        heat2d::head2d_problem, robertson::robertson,
         robertson_ode::robertson_ode,
     },
     FaerLU, FaerSparseLU, NalgebraLU, SparseColMat,
@@ -222,10 +222,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             c.bench_function(stringify!($name), |b| {
                 use diffsol::diffsl::LlvmModule;
                 use diffsol::ode_solver::test_models::robertson::*;
-                let mut context = diffsol::DiffSlContext::default();
-                robertson_diffsl_compile::<$matrix, LlvmModule>(&mut context);
                 b.iter(|| {
-                    let (problem, soln) = robertson_diffsl_problem(&mut context, false);
+                    let (problem, soln) = robertson_diffsl_problem::<$matrix, LlvmModule>();
                     let ls = $linear_solver::default();
                     benchmarks::$solver(&problem, soln.solution_points.last().unwrap().t, ls)
                 })
@@ -336,8 +334,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         ($name:ident, $solver:ident, $linear_solver:ident, $model:ident, $model_problem:ident, $matrix:ty, $($N:expr),+) => {
             $(c.bench_function(concat!(stringify!($name), "_", $N), |b| {
                 b.iter(|| {
-                    let context = FoodWebContext::default();
-                    let (problem, soln) = $model_problem::<$matrix, $N>(&context);
+                    let (problem, soln) = $model_problem::<$matrix, $N>();
                     let ls = $linear_solver::default();
                     benchmarks::$solver(&problem, soln.solution_points.last().unwrap().t, ls)
                 })
@@ -429,10 +426,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             c.bench_function(concat!(stringify!($name), "_", $N), |b| {
                 use diffsol::ode_solver::test_models::heat2d::*;
                 use diffsol::diffsl::LlvmModule;
-                let mut context = diffsol::DiffSlContext::default();
-                heat2d_diffsl_compile::<$matrix, LlvmModule, $N>(&mut context);
                 b.iter(|| {
-                    let (problem, soln) = heat2d_diffsl_problem(&mut context);
+                    let (problem, soln) = heat2d_diffsl_problem::<$matrix, LlvmModule, $N>();
                     let ls = $linear_solver::default();
                     benchmarks::$solver(&problem, soln.solution_points.last().unwrap().t, ls)
                 })
@@ -506,10 +501,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             c.bench_function(concat!(stringify!($name), "_", $N), |b| {
                 use diffsol::ode_solver::test_models::foodweb::*;
                 use diffsol::diffsl::LlvmModule;
-                let mut context = diffsol::DiffSlContext::default();
-                foodweb_diffsl_compile::<$matrix, LlvmModule, $N>(&mut context);
                 b.iter(|| {
-                    let (problem, soln) = foodweb_diffsl_problem(&mut context);
+                    let (problem, soln) = foodweb_diffsl_problem::<$matrix, LlvmModule, $N>();
                     let ls = $linear_solver::default();
                     benchmarks::$solver(&problem, soln.solution_points.last().unwrap().t, ls)
                 })

--- a/benches/ode_solvers.rs
+++ b/benches/ode_solvers.rs
@@ -2,8 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use diffsol::{
     ode_solver::test_models::{
         exponential_decay::exponential_decay_problem, foodweb::foodweb_problem,
-        heat2d::head2d_problem, robertson::robertson,
-        robertson_ode::robertson_ode,
+        heat2d::head2d_problem, robertson::robertson, robertson_ode::robertson_ode,
     },
     FaerLU, FaerSparseLU, NalgebraLU, SparseColMat,
 };

--- a/src/jacobian/mod.rs
+++ b/src/jacobian/mod.rs
@@ -93,7 +93,7 @@ pub struct JacobianColoring<M: Matrix> {
 }
 
 impl<M: Matrix> JacobianColoring<M> {
-    pub fn new(sparsity: & impl MatrixSparsity<M>, non_zeros: &[(usize, usize)]) -> Self {
+    pub fn new(sparsity: &impl MatrixSparsity<M>, non_zeros: &[(usize, usize)]) -> Self {
         let ncols = sparsity.ncols();
         let graph = nonzeros2graph(non_zeros, ncols);
         let coloring = color_graph_greedy(&graph);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Solving ODEs
 //!
 //! The simplest way to create a new problem is to use the [OdeBuilder] struct. You can set the initial time, initial step size, relative tolerance, absolute tolerance, and parameters,
-//! or leave them at their default values. Then, call one of the `build_*` functions (e.g. [OdeBuilder::build_ode], [OdeBuilder::build_ode_with_mass], [OdeBuilder::build_diffsl]) to create a [OdeSolverProblem].
+//! or leave them at their default values. Then, call one of the `build_*` functions (e.g. [OdeBuilder::build_ode], [OdeBuilder::build_ode_with_mass], [OdeBuilder::build_from_eqn]) to create a [OdeSolverProblem].
 //!
 //! You will also need to choose a matrix type to use. DiffSol can use the [nalgebra](https://nalgebra.org) `DMatrix` type, the [faer](https://github.com/sarah-ek/faer-rs) `Mat` type, or any other type that implements the
 //! [Matrix] trait.
@@ -35,7 +35,7 @@
 //! DiffSL is a domain-specific language for specifying differential equations <https://github.com/martinjrobins/diffsl>. It uses the LLVM compiler framwork
 //! to compile the equations to efficient machine code and uses the EnzymeAD library to compute the jacobian.
 //!
-//! You can use DiffSL with DiffSol using the [DiffSlContext] struct and [OdeBuilder::build_diffsl] method. You need to enable one of the `diffsl-llvm*` features
+//! You can use DiffSL with DiffSol using the [DiffSlContext] and [DiffSl] structs and [OdeBuilder::build_from_eqn] method. You need to enable one of the `diffsl-llvm*` features
 //! corresponding to the version of LLVM you have installed. E.g. to use your LLVM 10 installation, enable the `diffsl-llvm10` feature.
 //!
 //! For more information on the DiffSL language, see the [DiffSL documentation](https://martinjrobins.github.io/diffsl/)
@@ -54,7 +54,7 @@
 //! of the output vector `J(x) v` are also `NaN`, using the fact that `NaN`s propagate through most operations. However, this method is not foolproof and will fail if,
 //! for example, your jacobian function uses any control flow that depends on the input vector. If this is the case, you can provide the jacobian matrix directly by
 //! implementing the optional [NonLinearOpJacobian::jacobian_inplace] and the [LinearOp::matrix_inplace] (if applicable) functions,
-//! or by providing a sparsity pattern using the [Op::sparsity] function.
+//! or by providing a sparsity pattern using the [NonLinearOpJacobian::jacobian_sparsity] and [LinearOp::sparsity] functions.
 //!
 //! ## Events / Root finding
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub use ode_solver::sundials::SundialsIda;
 pub use linear_solver::suitesparse::klu::KLU;
 
 #[cfg(feature = "diffsl")]
-pub use ode_solver::diffsl::DiffSlContext;
+pub use ode_solver::diffsl::{DiffSlContext, DiffSl};
 
 pub use jacobian::{
     find_adjoint_non_zeros, find_jacobian_non_zeros, find_matrix_non_zeros,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub use ode_solver::{
     adjoint_equations::AdjointInit, adjoint_equations::AdjointRhs, bdf::Bdf, bdf::BdfAdj,
     bdf_state::BdfState, builder::OdeBuilder, checkpointing::Checkpointing,
     checkpointing::HermiteInterpolator, equations::AugmentedOdeEquations,
-    equations::AugmentedOdeEquationsImplicit, equations::NoAug, equations::OdeEquations,
+    equations::AugmentedOdeEquationsImplicit, equations::NoAug, equations::OdeEquations, equations::OdeEquationsRef,
     equations::OdeEquationsAdjoint, equations::OdeEquationsImplicit, equations::OdeEquationsSens,
     equations::OdeSolverEquations, method::AdjointOdeSolverMethod, method::OdeSolverMethod,
     method::OdeSolverStopReason, method::SensitivitiesOdeSolverMethod, problem::OdeSolverProblem,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub use ode_solver::sundials::SundialsIda;
 pub use linear_solver::suitesparse::klu::KLU;
 
 #[cfg(feature = "diffsl")]
-pub use ode_solver::diffsl::{DiffSlContext, DiffSl};
+pub use ode_solver::diffsl::{DiffSl, DiffSlContext};
 
 pub use jacobian::{
     find_adjoint_non_zeros, find_jacobian_non_zeros, find_matrix_non_zeros,
@@ -195,12 +195,13 @@ pub use ode_solver::{
     adjoint_equations::AdjointInit, adjoint_equations::AdjointRhs, bdf::Bdf, bdf::BdfAdj,
     bdf_state::BdfState, builder::OdeBuilder, checkpointing::Checkpointing,
     checkpointing::HermiteInterpolator, equations::AugmentedOdeEquations,
-    equations::AugmentedOdeEquationsImplicit, equations::NoAug, equations::OdeEquations, equations::OdeEquationsRef,
-    equations::OdeEquationsAdjoint, equations::OdeEquationsImplicit, equations::OdeEquationsSens,
-    equations::OdeSolverEquations, method::AdjointOdeSolverMethod, method::OdeSolverMethod,
-    method::OdeSolverStopReason, method::SensitivitiesOdeSolverMethod, problem::OdeSolverProblem,
-    sdirk::Sdirk, sdirk::SdirkAdj, sdirk_state::SdirkState, sens_equations::SensEquations,
-    sens_equations::SensInit, sens_equations::SensRhs, state::OdeSolverState, tableau::Tableau,
+    equations::AugmentedOdeEquationsImplicit, equations::NoAug, equations::OdeEquations,
+    equations::OdeEquationsAdjoint, equations::OdeEquationsImplicit, equations::OdeEquationsRef,
+    equations::OdeEquationsSens, equations::OdeSolverEquations, method::AdjointOdeSolverMethod,
+    method::OdeSolverMethod, method::OdeSolverStopReason, method::SensitivitiesOdeSolverMethod,
+    problem::OdeSolverProblem, sdirk::Sdirk, sdirk::SdirkAdj, sdirk_state::SdirkState,
+    sens_equations::SensEquations, sens_equations::SensInit, sens_equations::SensRhs,
+    state::OdeSolverState, tableau::Tableau,
 };
 pub use op::constant_op::{ConstantOp, ConstantOpSens, ConstantOpSensAdjoint};
 pub use op::linear_op::{LinearOp, LinearOpSens, LinearOpTranspose};

--- a/src/linear_solver/faer/lu.rs
+++ b/src/linear_solver/faer/lu.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 use crate::{error::LinearSolverError, linear_solver_error};
 
 use crate::{
-    error::DiffsolError, linear_solver::LinearSolver, Matrix,
-    NonLinearOpJacobian, Scalar,
+    error::DiffsolError, linear_solver::LinearSolver, Matrix, NonLinearOpJacobian, Scalar,
 };
 
 use faer::{linalg::solvers::FullPivLu, solvers::SpSolver, Col, Mat};

--- a/src/linear_solver/faer/lu.rs
+++ b/src/linear_solver/faer/lu.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use crate::{error::LinearSolverError, linear_solver_error};
 
 use crate::{
-    error::DiffsolError, linear_solver::LinearSolver, Matrix, MatrixSparsityRef,
+    error::DiffsolError, linear_solver::LinearSolver, Matrix,
     NonLinearOpJacobian, Scalar,
 };
 
@@ -58,7 +58,7 @@ impl<T: Scalar> LinearSolver<Mat<T>> for LU<T> {
     ) {
         let ncols = op.nstates();
         let nrows = op.nout();
-        let matrix = C::M::new_from_sparsity(nrows, ncols, op.sparsity().map(|s| s.to_owned()));
+        let matrix = C::M::new_from_sparsity(nrows, ncols, op.jacobian_sparsity());
         self.matrix = Some(matrix);
     }
 }

--- a/src/linear_solver/faer/sparse_lu.rs
+++ b/src/linear_solver/faer/sparse_lu.rs
@@ -4,7 +4,6 @@ use crate::{
     error::{DiffsolError, LinearSolverError},
     linear_solver::LinearSolver,
     linear_solver_error,
-    matrix::sparsity::MatrixSparsityRef,
     scalar::IndexType,
     Matrix, NonLinearOpJacobian, Scalar, SparseColMat,
 };
@@ -76,8 +75,7 @@ impl<T: Scalar> LinearSolver<SparseColMat<T>> for FaerSparseLU<T> {
         let matrix = C::M::new_from_sparsity(
             nrows,
             ncols,
-            op.sparsity()
-                .map(|s| MatrixSparsityRef::<SparseColMat<T>>::to_owned(&s)),
+            op.jacobian_sparsity()
         );
         self.matrix = Some(matrix);
         self.lu_symbolic = Some(

--- a/src/linear_solver/faer/sparse_lu.rs
+++ b/src/linear_solver/faer/sparse_lu.rs
@@ -72,11 +72,7 @@ impl<T: Scalar> LinearSolver<SparseColMat<T>> for FaerSparseLU<T> {
     ) {
         let ncols = op.nstates();
         let nrows = op.nout();
-        let matrix = C::M::new_from_sparsity(
-            nrows,
-            ncols,
-            op.jacobian_sparsity()
-        );
+        let matrix = C::M::new_from_sparsity(nrows, ncols, op.jacobian_sparsity());
         self.matrix = Some(matrix);
         self.lu_symbolic = Some(
             SymbolicLu::try_new(self.matrix.as_ref().unwrap().faer().symbolic())

--- a/src/linear_solver/nalgebra/lu.rs
+++ b/src/linear_solver/nalgebra/lu.rs
@@ -5,7 +5,6 @@ use nalgebra::{DMatrix, DVector, Dyn};
 use crate::{
     error::{DiffsolError, LinearSolverError},
     linear_solver_error,
-    matrix::sparsity::MatrixSparsityRef,
     LinearSolver, Matrix, NonLinearOpJacobian, Scalar,
 };
 
@@ -62,7 +61,7 @@ impl<T: Scalar> LinearSolver<DMatrix<T>> for LU<T> {
     ) {
         let ncols = op.nstates();
         let nrows = op.nout();
-        let matrix = C::M::new_from_sparsity(nrows, ncols, op.sparsity().map(|s| s.to_owned()));
+        let matrix = C::M::new_from_sparsity(nrows, ncols, op.jacobian_sparsity());
         self.matrix = Some(matrix);
     }
 }

--- a/src/linear_solver/nalgebra/lu.rs
+++ b/src/linear_solver/nalgebra/lu.rs
@@ -4,8 +4,7 @@ use nalgebra::{DMatrix, DVector, Dyn};
 
 use crate::{
     error::{DiffsolError, LinearSolverError},
-    linear_solver_error,
-    LinearSolver, Matrix, NonLinearOpJacobian, Scalar,
+    linear_solver_error, LinearSolver, Matrix, NonLinearOpJacobian, Scalar,
 };
 
 /// A [LinearSolver] that uses the LU decomposition in the [`nalgebra` library](https://nalgebra.org/) to solve the linear system.

--- a/src/linear_solver/suitesparse/klu.rs
+++ b/src/linear_solver/suitesparse/klu.rs
@@ -29,7 +29,7 @@ use crate::{
     linear_solver_error,
     matrix::MatrixCommon,
     vector::Vector,
-    Matrix, MatrixSparsityRef, NonLinearOpJacobian, SparseColMat,
+    Matrix, NonLinearOpJacobian, SparseColMat,
 };
 
 trait MatrixKLU: Matrix<T = f64> {
@@ -231,7 +231,7 @@ where
     ) {
         let ncols = op.nstates();
         let nrows = op.nout();
-        let mut matrix = C::M::new_from_sparsity(nrows, ncols, op.sparsity().map(|s| s.to_owned()));
+        let mut matrix = C::M::new_from_sparsity(nrows, ncols, op.jacobian_sparsity());
         let mut klu_common = self.klu_common.borrow_mut();
         self.klu_symbolic = KluSymbolic::try_from_matrix(&mut matrix, klu_common.as_mut()).ok();
         self.matrix = Some(matrix);

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -113,7 +113,7 @@ pub trait MatrixView<'a>:
 }
 
 /// A base matrix trait (including sparse and dense matrices)
-pub trait Matrix: MatrixCommon + Mul<Scale<Self::T>, Output = Self> + Clone {
+pub trait Matrix: MatrixCommon + Mul<Scale<Self::T>, Output = Self> + Clone + 'static {
     type Sparsity: MatrixSparsity<Self>;
     type SparsityRef<'a>: MatrixSparsityRef<'a, Self>
     where

--- a/src/matrix/sparse_faer.rs
+++ b/src/matrix/sparse_faer.rs
@@ -103,7 +103,7 @@ impl<T: Scalar> MatrixSparsity<SparseColMat<T>> for SymbolicSparseColMat<IndexTy
             Err(e) => Err(DiffsolError::Other(e.to_string())),
         }
     }
-    
+
     fn get_index(
         &self,
         rows: &[IndexType],
@@ -158,8 +158,6 @@ impl<'a, T: Scalar> MatrixSparsityRef<'a, SparseColMat<T>>
         }
         indices
     }
-
-    
 }
 
 impl<T: Scalar> Mul<Scale<T>> for SparseColMat<T> {

--- a/src/matrix/sparse_serial.rs
+++ b/src/matrix/sparse_serial.rs
@@ -138,13 +138,6 @@ impl<T: Scalar> MatrixSparsity<CscMatrix<T>> for SparsityPattern {
         major_offsets.push(n);
         SparsityPattern::try_from_offsets_and_indices(n, n, major_offsets, minor_indices).unwrap()
     }
-}
-
-impl<'a, T: Scalar> MatrixSparsityRef<'a, CscMatrix<T>> for &'a SparsityPattern {
-    fn to_owned(&self) -> SparsityPattern {
-        SparsityPattern::clone(self)
-    }
-
     fn get_index(&self, rows: &[IndexType], cols: &[IndexType]) -> DVector<IndexType> {
         let mut index = DVector::<IndexType>::zeros(rows.len());
         #[allow(unused_mut)]
@@ -156,6 +149,14 @@ impl<'a, T: Scalar> MatrixSparsityRef<'a, CscMatrix<T>> for &'a SparsityPattern 
         }
         index
     }
+}
+
+impl<'a, T: Scalar> MatrixSparsityRef<'a, CscMatrix<T>> for &'a SparsityPattern {
+    fn to_owned(&self) -> SparsityPattern {
+        SparsityPattern::clone(self)
+    }
+
+    
 
     fn nrows(&self) -> IndexType {
         self.minor_dim()

--- a/src/matrix/sparse_serial.rs
+++ b/src/matrix/sparse_serial.rs
@@ -156,8 +156,6 @@ impl<'a, T: Scalar> MatrixSparsityRef<'a, CscMatrix<T>> for &'a SparsityPattern 
         SparsityPattern::clone(self)
     }
 
-    
-
     fn nrows(&self) -> IndexType {
         self.minor_dim()
     }

--- a/src/matrix/sparsity.rs
+++ b/src/matrix/sparsity.rs
@@ -138,8 +138,6 @@ where
         false
     }
 
-    
-
     fn indices(&self) -> Vec<(IndexType, IndexType)> {
         Vec::new()
     }

--- a/src/matrix/sparsity.rs
+++ b/src/matrix/sparsity.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::Matrix;
 
-pub trait MatrixSparsity<M: Matrix>: Sized {
+pub trait MatrixSparsity<M: Matrix>: Sized + Clone {
     fn nrows(&self) -> IndexType;
     fn ncols(&self) -> IndexType;
     fn is_sparse() -> bool;
@@ -20,6 +20,7 @@ pub trait MatrixSparsity<M: Matrix>: Sized {
     fn union(self, other: M::SparsityRef<'_>) -> Result<M::Sparsity, DiffsolError>;
     fn new_diagonal(n: IndexType) -> Self;
     fn as_ref(&self) -> M::SparsityRef<'_>;
+    fn get_index(&self, rows: &[IndexType], cols: &[IndexType]) -> <M::V as Vector>::Index;
 }
 
 pub trait MatrixSparsityRef<'a, M: Matrix> {
@@ -28,9 +29,9 @@ pub trait MatrixSparsityRef<'a, M: Matrix> {
     fn is_sparse() -> bool;
     fn indices(&self) -> Vec<(IndexType, IndexType)>;
     fn to_owned(&self) -> M::Sparsity;
-    fn get_index(&self, rows: &[IndexType], cols: &[IndexType]) -> <M::V as Vector>::Index;
 }
 
+#[derive(Clone)]
 pub struct Dense<M: Matrix> {
     nrows: IndexType,
     ncols: IndexType,
@@ -102,6 +103,19 @@ where
     fn new_diagonal(n: IndexType) -> Self {
         Dense::new(n, n)
     }
+    fn get_index(&self, rows: &[IndexType], cols: &[IndexType]) -> <M::V as Vector>::Index {
+        let indices: Vec<_> = rows
+            .iter()
+            .zip(cols.iter())
+            .map(|(i, j)| {
+                if i >= &self.nrows() || j >= &self.ncols() {
+                    panic!("Index out of bounds")
+                }
+                j * self.nrows() + i
+            })
+            .collect();
+        <M::V as Vector>::Index::from_slice(indices.as_slice())
+    }
 }
 
 impl<'a, M> MatrixSparsityRef<'a, M> for DenseRef<'a, M>
@@ -124,19 +138,7 @@ where
         false
     }
 
-    fn get_index(&self, rows: &[IndexType], cols: &[IndexType]) -> <M::V as Vector>::Index {
-        let indices: Vec<_> = rows
-            .iter()
-            .zip(cols.iter())
-            .map(|(i, j)| {
-                if i >= &self.nrows() || j >= &self.ncols() {
-                    panic!("Index out of bounds")
-                }
-                j * self.nrows() + i
-            })
-            .collect();
-        <M::V as Vector>::Index::from_slice(indices.as_slice())
-    }
+    
 
     fn indices(&self) -> Vec<(IndexType, IndexType)> {
         Vec::new()

--- a/src/ode_solver/adjoint_equations.rs
+++ b/src/ode_solver/adjoint_equations.rs
@@ -1,11 +1,15 @@
 use num_traits::{One, Zero};
-use std::{cell::RefCell, ops::{AddAssign, SubAssign}, rc::Rc};
+use std::{
+    cell::RefCell,
+    ops::{AddAssign, SubAssign},
+    rc::Rc,
+};
 
 use crate::{
     op::nonlinear_op::NonLinearOpJacobian, AugmentedOdeEquations, Checkpointing, ConstantOp,
     ConstantOpSensAdjoint, LinearOp, LinearOpTranspose, Matrix, NonLinearOp, NonLinearOpAdjoint,
-    NonLinearOpSensAdjoint, OdeEquations, OdeEquationsAdjoint, OdeSolverMethod, OdeSolverProblem,
-    Op, Vector, OdeEquationsRef
+    NonLinearOpSensAdjoint, OdeEquations, OdeEquationsAdjoint, OdeEquationsRef, OdeSolverMethod,
+    OdeSolverProblem, Op, Vector,
 };
 
 pub struct AdjointContext<Eqn, Method>
@@ -217,7 +221,6 @@ where
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    
 }
 
 impl<Eqn, Method> NonLinearOp for AdjointRhs<Eqn, Method>
@@ -328,7 +331,6 @@ where
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    
 }
 
 impl<Eqn, Method> NonLinearOp for AdjointOut<Eqn, Method>
@@ -508,7 +510,6 @@ where
     }
 }
 
-
 impl<'a, Eqn, Method> OdeEquationsRef<'a> for AdjointEquations<Eqn, Method>
 where
     Eqn: OdeEquationsAdjoint,
@@ -521,9 +522,8 @@ where
     type Out = &'a AdjointOut<Eqn, Method>;
 }
 
-
-impl<Eqn, Method> OdeEquations for AdjointEquations<Eqn, Method> 
-where 
+impl<Eqn, Method> OdeEquations for AdjointEquations<Eqn, Method>
+where
     Eqn: OdeEquationsAdjoint,
     Method: OdeSolverMethod<Eqn>,
 {

--- a/src/ode_solver/adjoint_equations.rs
+++ b/src/ode_solver/adjoint_equations.rs
@@ -468,10 +468,10 @@ where
                 mass.call_transpose_inplace(s_i, t, &mut tmp2);
                 self.eqn
                     .init()
-                    .sens_mul_transpose_inplace(t, &tmp2, &mut tmp);
+                    .sens_transpose_mul_inplace(t, &tmp2, &mut tmp);
                 sg_i.sub_assign(&*tmp);
             } else {
-                self.eqn.init().sens_mul_transpose_inplace(t, s_i, &mut tmp);
+                self.eqn.init().sens_transpose_mul_inplace(t, s_i, &mut tmp);
                 sg_i.sub_assign(&*tmp);
             }
         }
@@ -508,54 +508,6 @@ where
     }
 }
 
-//trait Op {}
-//trait SuperOp: Op {}
-//
-//
-//// https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#
-//trait EqnRef<'a, ImplicitBounds: Sealed = Bounds<&'a Self>> {
-//    type Rhs: Op;
-//}
-//
-//mod sealed {
-//	pub trait Sealed: Sized {}
-//	pub struct Bounds<T>(T);
-//	impl<T> Sealed for Bounds<T> {}
-//}
-//use sealed::{Bounds, Sealed};
-//
-//trait Eqn: for <'a> EqnRef<'a> {}
-//
-//trait SuperEqn: Eqn<Rhs: SuperOp> {}
-//
-//impl<T> SuperEqn for T where T: Eqn<Rhs: SuperOp> {}
-//
-//struct DefaultEqn<T: Eqn> {
-//    _a: PhantomData<T>,
-//}
-//
-//impl<'a, T: Eqn> EqnRef<'a> for DefaultEqn<T> {
-//    type Rhs = <T as EqnRef<'a>>::Rhs;
-//}
-//
-//impl<T: Eqn> Eqn for DefaultEqn<T> 
-//{
-//}
-//
-//struct Solver<T: SuperEqn, T2: SuperEqn = DefaultEqn<T>> {
-//    _a: PhantomData<T>,
-//    _b: PhantomData<T2>,
-//}
-//
-//impl<T: SuperEqn> Solver<T> 
-//{
-//    fn new() -> Self {
-//        Self {
-//            _a: PhantomData,
-//            _b: PhantomData,
-//        }
-//    }
-//}
 
 impl<'a, Eqn, Method> OdeEquationsRef<'a> for AdjointEquations<Eqn, Method>
 where

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -1193,7 +1193,7 @@ mod test {
                     exponential_decay_with_algebraic_problem,
                     exponential_decay_with_algebraic_problem_sens,
                 },
-                foodweb::{foodweb_problem, FoodWebContext},
+                foodweb::foodweb_problem,
                 gaussian_decay::gaussian_decay_problem,
                 heat2d::head2d_problem,
                 robertson::{robertson, robertson_sens},
@@ -1466,10 +1466,8 @@ mod test {
         use diffsl::LlvmModule;
 
         use crate::ode_solver::test_models::robertson;
-        let mut context = crate::DiffSlContext::default();
         let mut s = Bdf::default();
-        robertson::robertson_diffsl_compile(&mut context);
-        let (problem, soln) = robertson::robertson_diffsl_problem::<M, LlvmModule>(&context, false);
+        let (problem, soln) = robertson::robertson_diffsl_problem::<M, LlvmModule>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
     }
 
@@ -1656,23 +1654,20 @@ mod test {
     fn test_bdf_faer_sparse_heat2d_diffsl() {
         use diffsl::LlvmModule;
 
-        use crate::ode_solver::test_models::heat2d::{self, heat2d_diffsl_compile};
+        use crate::ode_solver::test_models::heat2d;
         let linear_solver = FaerSparseLU::default();
         let nonlinear_solver = NewtonNonlinearSolver::new(linear_solver);
-        let mut context = crate::DiffSlContext::default();
         let mut s = Bdf::<Mat<f64>, _, _>::new(nonlinear_solver);
-        heat2d_diffsl_compile::<SparseColMat<f64>, LlvmModule, 10>(&mut context);
-        let (problem, soln) = heat2d::heat2d_diffsl_problem(&context);
+        let (problem, soln) = heat2d::heat2d_diffsl_problem::<SparseColMat<f64>, LlvmModule, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
     }
 
     #[test]
     fn test_bdf_faer_sparse_foodweb() {
-        let foodweb_context = FoodWebContext::default();
         let linear_solver = FaerSparseLU::default();
         let nonlinear_solver = NewtonNonlinearSolver::new(linear_solver);
         let mut s = Bdf::<Mat<f64>, _, _>::new(nonlinear_solver);
-        let (problem, soln) = foodweb_problem::<SparseColMat<f64>, 10>(&foodweb_context);
+        let (problem, soln) = foodweb_problem::<SparseColMat<f64>, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
         ---
@@ -1690,12 +1685,10 @@ mod test {
         use diffsl::LlvmModule;
 
         use crate::ode_solver::test_models::foodweb;
-        let mut context = crate::DiffSlContext::default();
         let linear_solver = FaerSparseLU::default();
         let nonlinear_solver = NewtonNonlinearSolver::new(linear_solver);
         let mut s = Bdf::<Mat<f64>, _, _>::new(nonlinear_solver);
-        foodweb::foodweb_diffsl_compile::<SparseColMat<f64>, LlvmModule, 10>(&mut context);
-        let (problem, soln) = foodweb::foodweb_diffsl_problem(&context);
+        let (problem, soln) = foodweb::foodweb_diffsl_problem::<SparseColMat<f64>, LlvmModule, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
     }
 

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -1250,7 +1250,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 11
         number_of_steps: 47
         number_of_error_test_failures: 0
@@ -1258,7 +1257,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 84
         number_of_jac_muls: 2
         number_of_matrix_evals: 1
@@ -1288,7 +1286,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 11
         number_of_steps: 47
         number_of_error_test_failures: 0
@@ -1296,7 +1293,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 84
         number_of_jac_muls: 2
         number_of_matrix_evals: 1
@@ -1310,7 +1306,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 11
         number_of_steps: 44
         number_of_error_test_failures: 0
@@ -1318,7 +1313,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 87
         number_of_jac_muls: 136
         number_of_matrix_evals: 1
@@ -1332,14 +1326,12 @@ mod test {
         let (problem, soln) = exponential_decay_problem_adjoint::<M>();
         let adjoint_solver = test_ode_solver_adjoint(s, &problem, soln);
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
-        ---
         number_of_calls: 84
         number_of_jac_muls: 6
         number_of_matrix_evals: 3
         number_of_jac_adj_muls: 492
         "###);
         insta::assert_yaml_snapshot!(adjoint_solver.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 24
         number_of_steps: 86
         number_of_error_test_failures: 12
@@ -1354,14 +1346,12 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_adjoint_problem::<M>();
         let adjoint_solver = test_ode_solver_adjoint(s, &problem, soln);
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
-        ---
         number_of_calls: 190
         number_of_jac_muls: 24
         number_of_matrix_evals: 8
         number_of_jac_adj_muls: 278
         "###);
         insta::assert_yaml_snapshot!(adjoint_solver.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 32
         number_of_steps: 74
         number_of_error_test_failures: 15
@@ -1376,7 +1366,6 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_problem::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 20
         number_of_steps: 41
         number_of_error_test_failures: 4
@@ -1384,7 +1373,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 83
         number_of_jac_muls: 6
         number_of_matrix_evals: 2
@@ -1407,7 +1395,6 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_problem_sens::<M>();
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 18
         number_of_steps: 43
         number_of_error_test_failures: 3
@@ -1415,7 +1402,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 71
         number_of_jac_muls: 100
         number_of_matrix_evals: 3
@@ -1429,7 +1415,6 @@ mod test {
         let (problem, soln) = robertson::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 77
         number_of_steps: 316
         number_of_error_test_failures: 3
@@ -1437,7 +1422,6 @@ mod test {
         number_of_nonlinear_solver_fails: 19
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 725
         number_of_jac_muls: 60
         number_of_matrix_evals: 20
@@ -1481,7 +1465,6 @@ mod test {
         let (problem, soln) = robertson_sens::<M>();
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 160
         number_of_steps: 410
         number_of_error_test_failures: 4
@@ -1489,7 +1472,6 @@ mod test {
         number_of_nonlinear_solver_fails: 81
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 996
         number_of_jac_muls: 2495
         number_of_matrix_evals: 71
@@ -1503,7 +1485,6 @@ mod test {
         let (problem, soln) = robertson::<M>(true);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 77
         number_of_steps: 316
         number_of_error_test_failures: 3
@@ -1511,7 +1492,6 @@ mod test {
         number_of_nonlinear_solver_fails: 19
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 725
         number_of_jac_muls: 63
         number_of_matrix_evals: 20
@@ -1525,7 +1505,6 @@ mod test {
         let (problem, soln) = robertson_ode::<M>(false, 3);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 86
         number_of_steps: 416
         number_of_error_test_failures: 1
@@ -1533,7 +1512,6 @@ mod test {
         number_of_nonlinear_solver_fails: 15
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 913
         number_of_jac_muls: 162
         number_of_matrix_evals: 18
@@ -1547,7 +1525,6 @@ mod test {
         let (problem, soln) = robertson_ode_with_sens::<M>(false);
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 112
         number_of_steps: 467
         number_of_error_test_failures: 2
@@ -1555,7 +1532,6 @@ mod test {
         number_of_nonlinear_solver_fails: 49
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 1041
         number_of_jac_muls: 2672
         number_of_matrix_evals: 45
@@ -1569,7 +1545,6 @@ mod test {
         let (problem, soln) = dydt_y2_problem::<M>(false, 10);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 27
         number_of_steps: 161
         number_of_error_test_failures: 0
@@ -1577,7 +1552,6 @@ mod test {
         number_of_nonlinear_solver_fails: 3
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 357
         number_of_jac_muls: 50
         number_of_matrix_evals: 5
@@ -1591,7 +1565,6 @@ mod test {
         let (problem, soln) = dydt_y2_problem::<M>(true, 10);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 27
         number_of_steps: 161
         number_of_error_test_failures: 0
@@ -1599,7 +1572,6 @@ mod test {
         number_of_nonlinear_solver_fails: 3
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 357
         number_of_jac_muls: 15
         number_of_matrix_evals: 5
@@ -1613,7 +1585,6 @@ mod test {
         let (problem, soln) = gaussian_decay_problem::<M>(false, 10);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 14
         number_of_steps: 66
         number_of_error_test_failures: 1
@@ -1621,7 +1592,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 132
         number_of_jac_muls: 20
         number_of_matrix_evals: 2
@@ -1637,7 +1607,6 @@ mod test {
         let (problem, soln) = head2d_problem::<SparseColMat<f64>, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 21
         number_of_steps: 167
         number_of_error_test_failures: 0
@@ -1645,7 +1614,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 333
         number_of_jac_muls: 128
         number_of_matrix_evals: 4
@@ -1674,7 +1642,6 @@ mod test {
         let (problem, soln) = foodweb_problem::<SparseColMat<f64>, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 45
         number_of_steps: 161
         number_of_error_test_failures: 2

--- a/src/ode_solver/bdf.rs
+++ b/src/ode_solver/bdf.rs
@@ -3,7 +3,9 @@ use std::ops::AddAssign;
 use std::rc::Rc;
 
 use crate::{
-    error::{DiffsolError, OdeSolverError}, AdjointEquations, AugmentedOdeEquationsImplicit, NoAug, OdeEquationsAdjoint, OdeEquationsSens, SensEquations, StateRef, StateRefMut
+    error::{DiffsolError, OdeSolverError},
+    AdjointEquations, AugmentedOdeEquationsImplicit, NoAug, OdeEquationsAdjoint, OdeEquationsSens,
+    SensEquations, StateRef, StateRefMut,
 };
 
 use num_traits::{abs, One, Pow, Zero};
@@ -23,7 +25,9 @@ use crate::{
 };
 
 use super::jacobian_update::SolverState;
-use super::method::{AdjointOdeSolverMethod, AugmentedOdeSolverMethod, SensitivitiesOdeSolverMethod};
+use super::method::{
+    AdjointOdeSolverMethod, AugmentedOdeSolverMethod, SensitivitiesOdeSolverMethod,
+};
 
 #[derive(Clone, Debug, Serialize, Default)]
 pub struct BdfStatistics {
@@ -1688,7 +1692,8 @@ mod test {
         let linear_solver = FaerSparseLU::default();
         let nonlinear_solver = NewtonNonlinearSolver::new(linear_solver);
         let mut s = Bdf::<Mat<f64>, _, _>::new(nonlinear_solver);
-        let (problem, soln) = foodweb::foodweb_diffsl_problem::<SparseColMat<f64>, LlvmModule, 10>();
+        let (problem, soln) =
+            foodweb::foodweb_diffsl_problem::<SparseColMat<f64>, LlvmModule, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
     }
 

--- a/src/ode_solver/builder.rs
+++ b/src/ode_solver/builder.rs
@@ -225,7 +225,7 @@ impl OdeBuilder {
         nstates: usize,
         nout: Option<usize>,
         nparam: usize,
-    ) -> Result<(V, Option<V>, Option<V>, Option<V>), DiffsolError> {
+    ) -> Result<(Rc<V>, Option<Rc<V>>, Option<Rc<V>>, Option<Rc<V>>), DiffsolError> {
         let atol = Self::build_atol(atol, nstates, "states")?;
         let out_atol = match out_atol {
             Some(out_atol) => Some(Self::build_atol(out_atol, nout.unwrap_or(0), "output")?),
@@ -239,7 +239,7 @@ impl OdeBuilder {
             Some(sens_atol) => Some(Self::build_atol(sens_atol, nstates, "sensitivity")?),
             None => None,
         };
-        Ok((atol, sens_atol, out_atol, param_atol))
+        Ok((Rc::new(atol), sens_atol.map(Rc::new), out_atol.map(Rc::new), param_atol.map(Rc::new)))
     }
 
     fn build_p<V: Vector>(p: Vec<f64>) -> V {
@@ -335,7 +335,7 @@ impl OdeBuilder {
         )?;
         let eqn = OdeSolverEquations::new(rhs, mass, None, init, None, p);
         OdeSolverProblem::new(
-            eqn,
+            Rc::new(eqn),
             M::T::from(self.rtol),
             atol,
             self.sens_rtol.map(M::T::from),
@@ -409,7 +409,7 @@ impl OdeBuilder {
             nparams,
         )?;
         OdeSolverProblem::new(
-            eqn,
+            Rc::new(eqn),
             M::T::from(self.rtol),
             atol,
             self.sens_rtol.map(M::T::from),
@@ -492,7 +492,7 @@ impl OdeBuilder {
             nparams,
         )?;
         OdeSolverProblem::new(
-            eqn,
+            Rc::new(eqn),
             M::T::from(self.rtol),
             atol,
             self.sens_rtol.map(M::T::from),
@@ -580,7 +580,7 @@ impl OdeBuilder {
             nparams,
         )?;
         OdeSolverProblem::new(
-            eqn,
+            Rc::new(eqn),
             M::T::from(self.rtol),
             atol,
             self.sens_rtol.map(M::T::from),
@@ -680,7 +680,7 @@ impl OdeBuilder {
             nparams,
         )?;
         OdeSolverProblem::new(
-            eqn,
+            Rc::new(eqn),
             M::T::from(self.rtol),
             atol,
             self.sens_rtol.map(M::T::from),
@@ -716,7 +716,7 @@ impl OdeBuilder {
     }
 
     /// Build an ODE problem from a set of equations
-    pub fn build_from_eqn<Eqn>(self, eqn: Eqn) -> Result<OdeSolverProblem<Eqn>, DiffsolError>
+    pub fn build_from_eqn<Eqn>(self, eqn: Rc<Eqn>) -> Result<OdeSolverProblem<Eqn>, DiffsolError>
     where
         Eqn: OdeEquations,
     {

--- a/src/ode_solver/builder.rs
+++ b/src/ode_solver/builder.rs
@@ -239,7 +239,12 @@ impl OdeBuilder {
             Some(sens_atol) => Some(Self::build_atol(sens_atol, nstates, "sensitivity")?),
             None => None,
         };
-        Ok((Rc::new(atol), sens_atol.map(Rc::new), out_atol.map(Rc::new), param_atol.map(Rc::new)))
+        Ok((
+            Rc::new(atol),
+            sens_atol.map(Rc::new),
+            out_atol.map(Rc::new),
+            param_atol.map(Rc::new),
+        ))
     }
 
     fn build_p<V: Vector>(p: Vec<f64>) -> V {

--- a/src/ode_solver/builder.rs
+++ b/src/ode_solver/builder.rs
@@ -721,7 +721,7 @@ impl OdeBuilder {
     }
 
     /// Build an ODE problem from a set of equations
-    pub fn build_from_eqn<Eqn>(self, eqn: Rc<Eqn>) -> Result<OdeSolverProblem<Eqn>, DiffsolError>
+    pub fn build_from_eqn<Eqn>(self, mut eqn: Eqn) -> Result<OdeSolverProblem<Eqn>, DiffsolError>
     where
         Eqn: OdeEquations,
     {
@@ -737,8 +737,10 @@ impl OdeBuilder {
             nout,
             nparams,
         )?;
+        let p = Rc::new(Self::build_p(self.p));
+        eqn.set_params(p);
         OdeSolverProblem::new(
-            eqn,
+            Rc::new(eqn),
             Eqn::T::from(self.rtol),
             atol,
             self.sens_rtol.map(Eqn::T::from),

--- a/src/ode_solver/diffsl.rs
+++ b/src/ode_solver/diffsl.rs
@@ -3,10 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use diffsl::{execution::module::CodegenModule, Compiler};
 
 use crate::{
-    error::DiffsolError, find_jacobian_non_zeros, find_matrix_non_zeros,
-    jacobian::JacobianColoring, matrix::sparsity::MatrixSparsity,
-    op::nonlinear_op::NonLinearOpJacobian, ConstantOp, LinearOp, Matrix, NonLinearOp, OdeEquations,
-    Op, Vector,
+    error::DiffsolError, find_jacobian_non_zeros, find_matrix_non_zeros, jacobian::JacobianColoring, matrix::sparsity::MatrixSparsity, op::nonlinear_op::NonLinearOpJacobian, ConstantOp, LinearOp, Matrix, NonLinearOp, OdeEquations, OdeEquationsRef, Op, Vector
 };
 
 pub type T = f64;
@@ -107,120 +104,53 @@ impl<M: Matrix<T = T>, CG: CodegenModule> Default for DiffSlContext<M, CG> {
     }
 }
 
-pub struct DiffSl<'a, M: Matrix<T = T>, CG: CodegenModule> {
-    context: &'a DiffSlContext<M, CG>,
-    rhs: Rc<DiffSlRhs<'a, M, CG>>,
-    mass: Option<Rc<DiffSlMass<'a, M, CG>>>,
-    root: Rc<DiffSlRoot<'a, M, CG>>,
-    init: Rc<DiffSlInit<'a, M, CG>>,
-    out: Rc<DiffSlOut<'a, M, CG>>,
+pub struct DiffSl<M: Matrix<T = T>, CG: CodegenModule> {
+    context: DiffSlContext<M, CG>,
+    mass_sparsity: Option<M::Sparsity>,
+    mass_coloring: Option<JacobianColoring<M>>,
+    rhs_sparsity: Option<M::Sparsity>,
+    rhs_coloring: Option<JacobianColoring<M>>,
+    
 }
 
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> DiffSl<'a, M, CG> {
-    pub fn new(context: &'a DiffSlContext<M, CG>, use_coloring: bool) -> Self {
-        let rhs = Rc::new(DiffSlRhs::new(context, use_coloring));
-        let mass = DiffSlMass::new(context, use_coloring).map(Rc::new);
-        let root = Rc::new(DiffSlRoot::new(context));
-        let init = Rc::new(DiffSlInit::new(context));
-        let out = Rc::new(DiffSlOut::new(context));
-        Self {
-            context,
-            rhs,
-            mass,
-            root,
-            init,
-            out,
-        }
-    }
-}
-
-pub struct DiffSlRoot<'a, M: Matrix<T = T>, CG: CodegenModule> {
-    context: &'a DiffSlContext<M, CG>,
-}
-
-pub struct DiffSlOut<'a, M: Matrix<T = T>, CG: CodegenModule> {
-    context: &'a DiffSlContext<M, CG>,
-}
-
-pub struct DiffSlRhs<'a, M: Matrix<T = T>, CG: CodegenModule> {
-    context: &'a DiffSlContext<M, CG>,
-    coloring: Option<JacobianColoring<M>>,
-    sparsity: Option<M::Sparsity>,
-}
-
-pub struct DiffSlMass<'a, M: Matrix<T = T>, CG: CodegenModule> {
-    context: &'a DiffSlContext<M, CG>,
-    coloring: Option<JacobianColoring<M>>,
-    sparsity: Option<M::Sparsity>,
-}
-
-pub struct DiffSlInit<'a, M: Matrix<T = T>, CG: CodegenModule> {
-    context: &'a DiffSlContext<M, CG>,
-}
-
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> DiffSlOut<'a, M, CG> {
-    pub fn new(context: &'a DiffSlContext<M, CG>) -> Self {
-        Self { context }
-    }
-}
-
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> DiffSlRoot<'a, M, CG> {
-    pub fn new(context: &'a DiffSlContext<M, CG>) -> Self {
-        Self { context }
-    }
-}
-
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> DiffSlInit<'a, M, CG> {
-    pub fn new(context: &'a DiffSlContext<M, CG>) -> Self {
-        Self { context }
-    }
-}
-
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> DiffSlRhs<'a, M, CG> {
-    pub fn new(context: &'a DiffSlContext<M, CG>, use_coloring: bool) -> Self {
+impl<M: Matrix<T = T>, CG: CodegenModule> DiffSl<M, CG> {
+    pub fn from_context(context: DiffSlContext<M, CG>) -> Self {
         let mut ret = Self {
             context,
-            coloring: None,
-            sparsity: None,
+            mass_coloring: None,
+            mass_sparsity: None,
+            rhs_coloring: None,
+            rhs_sparsity: None,
         };
-
-        if use_coloring {
-            let x0 = M::V::zeros(context.nstates);
+        if M::is_sparse() {
+            let op = ret.rhs();
             let t0 = 0.0;
-            let non_zeros = find_jacobian_non_zeros(&ret, &x0, t0);
-            ret.sparsity = Some(
-                MatrixSparsity::try_from_indices(ret.nout(), ret.nstates(), non_zeros.clone())
-                    .expect("invalid sparsity pattern"),
-            );
-            ret.coloring = Some(JacobianColoring::new_from_non_zeros(&ret, non_zeros));
+            let x0 = M::V::zeros(op.nstates());
+            let non_zeros = find_jacobian_non_zeros(&op, &x0, t0);
+            let sparsity = M::Sparsity::try_from_indices(op.nout(), op.nstates(), non_zeros.clone())
+                    .expect("invalid sparsity pattern");
+            let coloring = JacobianColoring::new_from_sparsity(&sparsity);
+            ret.rhs_coloring = Some(coloring);
+            ret.rhs_sparsity = Some(sparsity);
+            
+            let op = ret.mass().unwrap();
+            let non_zeros = find_matrix_non_zeros(&op, t0);
+            let sparsity = M::Sparsity::try_from_indices(op.nout(), op.nstates(), non_zeros.clone())
+                    .expect("invalid sparsity pattern");
+            let coloring = JacobianColoring::new_from_sparsity(&sparsity);
+            ret.mass_coloring = Some(coloring);
+            ret.mass_sparsity = Some(sparsity);
         }
         ret
     }
 }
 
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> DiffSlMass<'a, M, CG> {
-    pub fn new(context: &'a DiffSlContext<M, CG>, use_coloring: bool) -> Option<Self> {
-        if !context.compiler.has_mass() {
-            return None;
-        }
-        let mut ret = Self {
-            context,
-            coloring: None,
-            sparsity: None,
-        };
+pub struct DiffSlRoot<'a, M: Matrix<T = T>, CG: CodegenModule>(&'a DiffSl<M, CG>);
+pub struct DiffSlOut<'a, M: Matrix<T = T>, CG: CodegenModule>(&'a DiffSl<M, CG>);
+pub struct DiffSlRhs<'a, M: Matrix<T = T>, CG: CodegenModule>(&'a DiffSl<M, CG>);
+pub struct DiffSlMass<'a, M: Matrix<T = T>, CG: CodegenModule>(&'a DiffSl<M, CG>);
+pub struct DiffSlInit<'a, M: Matrix<T = T>, CG: CodegenModule>(&'a DiffSl<M, CG>);
 
-        if use_coloring {
-            let t0 = 0.0;
-            let non_zeros = find_matrix_non_zeros(&ret, t0);
-            ret.sparsity = Some(
-                MatrixSparsity::try_from_indices(ret.nout(), ret.nstates(), non_zeros.clone())
-                    .expect("invalid sparsity pattern"),
-            );
-            ret.coloring = Some(JacobianColoring::new_from_non_zeros(&ret, non_zeros));
-        }
-        Some(ret)
-    }
-}
 
 macro_rules! impl_op_for_diffsl {
     ($name:ident) => {
@@ -230,18 +160,16 @@ macro_rules! impl_op_for_diffsl {
             type V = M::V;
 
             fn nstates(&self) -> usize {
-                self.context.nstates
+                self.0.context.nstates
             }
             #[allow(clippy::misnamed_getters)]
             fn nout(&self) -> usize {
-                self.context.nstates
+                self.0.context.nstates
             }
             fn nparams(&self) -> usize {
-                self.context.nparams
+                self.0.context.nparams
             }
-            fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-                self.sparsity.as_ref().map(|s| s.as_ref())
-            }
+            
         }
     };
 }
@@ -255,14 +183,14 @@ impl<M: Matrix<T = T>, CG: CodegenModule> Op for DiffSlInit<'_, M, CG> {
     type V = M::V;
 
     fn nstates(&self) -> usize {
-        self.context.nstates
+        self.0.context.nstates
     }
     #[allow(clippy::misnamed_getters)]
     fn nout(&self) -> usize {
-        self.context.nstates
+        self.0.context.nstates
     }
     fn nparams(&self) -> usize {
-        self.context.nparams
+        self.0.context.nparams
     }
 }
 
@@ -272,14 +200,14 @@ impl<M: Matrix<T = T>, CG: CodegenModule> Op for DiffSlRoot<'_, M, CG> {
     type V = M::V;
 
     fn nstates(&self) -> usize {
-        self.context.nstates
+        self.0.context.nstates
     }
     #[allow(clippy::misnamed_getters)]
     fn nout(&self) -> usize {
-        self.context.nroots
+        self.0.context.nroots
     }
     fn nparams(&self) -> usize {
-        self.context.nparams
+        self.0.context.nparams
     }
 }
 
@@ -289,31 +217,31 @@ impl<M: Matrix<T = T>, CG: CodegenModule> Op for DiffSlOut<'_, M, CG> {
     type V = M::V;
 
     fn nstates(&self) -> usize {
-        self.context.nstates
+        self.0.context.nstates
     }
     fn nout(&self) -> usize {
-        self.context.nout
+        self.0.context.nout
     }
     fn nparams(&self) -> usize {
-        self.context.nparams
+        self.0.context.nparams
     }
 }
 
 impl<M: Matrix<T = T>, CG: CodegenModule> ConstantOp for DiffSlInit<'_, M, CG> {
     fn call_inplace(&self, _t: Self::T, y: &mut Self::V) {
-        self.context.compiler.set_u0(
+        self.0.context.compiler.set_u0(
             y.as_mut_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
         );
     }
 }
 
 impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOp for DiffSlRoot<'_, M, CG> {
     fn call_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::V) {
-        self.context.compiler.calc_stop(
+        self.0.context.compiler.calc_stop(
             t,
             x.as_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
             y.as_mut_slice(),
         );
     }
@@ -327,42 +255,43 @@ impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOpJacobian for DiffSlRoot<'_,
 
 impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOp for DiffSlOut<'_, M, CG> {
     fn call_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::V) {
-        self.context.compiler.calc_out(
+        self.0.context.compiler.calc_out(
             t,
             x.as_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
         );
         let out = self
-            .context
+            .0.context
             .compiler
-            .get_out(self.context.data.borrow().as_slice());
+            .get_out(self.0.context.data.borrow().as_slice());
         y.copy_from_slice(out);
     }
 }
 
 impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOpJacobian for DiffSlOut<'_, M, CG> {
     fn jac_mul_inplace(&self, x: &Self::V, t: Self::T, v: &Self::V, y: &mut Self::V) {
-        self.context.compiler.calc_out_grad(
+        self.0.context.compiler.calc_out_grad(
             t,
             x.as_slice(),
             v.as_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
-            self.context.ddata.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.ddata.borrow_mut().as_mut_slice(),
         );
         let out_grad = self
-            .context
+            .0.context
             .compiler
-            .get_out(self.context.ddata.borrow().as_slice());
+            .get_out(self.0.context.ddata.borrow().as_slice());
         y.copy_from_slice(out_grad);
     }
+    
 }
 
 impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOp for DiffSlRhs<'_, M, CG> {
     fn call_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::V) {
-        self.context.compiler.rhs(
+        self.0.context.compiler.rhs(
             t,
             x.as_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
             y.as_mut_slice(),
         );
     }
@@ -371,33 +300,36 @@ impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOp for DiffSlRhs<'_, M, CG> {
 impl<M: Matrix<T = T>, CG: CodegenModule> NonLinearOpJacobian for DiffSlRhs<'_, M, CG> {
     fn jac_mul_inplace(&self, x: &Self::V, t: Self::T, v: &Self::V, y: &mut Self::V) {
         let mut dummy_rhs = Self::V::zeros(self.nstates());
-        self.context.compiler.rhs_grad(
+        self.0.context.compiler.rhs_grad(
             t,
             x.as_slice(),
             v.as_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
-            self.context.ddata.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.ddata.borrow_mut().as_mut_slice(),
             dummy_rhs.as_mut_slice(),
             y.as_mut_slice(),
         );
     }
 
     fn jacobian_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::M) {
-        if let Some(coloring) = &self.coloring {
+        if let Some(coloring) = &self.0.rhs_coloring {
             coloring.jacobian_inplace(self, x, t, y);
         } else {
             self._default_jacobian_inplace(x, t, y);
         }
     }
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.0.rhs_sparsity.as_ref().map(|s| s.clone())
+    }
 }
 
 impl<M: Matrix<T = T>, CG: CodegenModule> LinearOp for DiffSlMass<'_, M, CG> {
     fn gemv_inplace(&self, x: &Self::V, t: Self::T, beta: Self::T, y: &mut Self::V) {
-        let mut tmp = self.context.tmp.borrow_mut();
-        self.context.compiler.mass(
+        let mut tmp = self.0.context.tmp.borrow_mut();
+        self.0.context.compiler.mass(
             t,
             x.as_slice(),
-            self.context.data.borrow_mut().as_mut_slice(),
+            self.0.context.data.borrow_mut().as_mut_slice(),
             tmp.as_mut_slice(),
         );
 
@@ -406,37 +338,32 @@ impl<M: Matrix<T = T>, CG: CodegenModule> LinearOp for DiffSlMass<'_, M, CG> {
     }
 
     fn matrix_inplace(&self, t: Self::T, y: &mut Self::M) {
-        if let Some(coloring) = &self.coloring {
+        if let Some(coloring) = &self.0.mass_coloring {
             coloring.matrix_inplace(self, t, y);
         } else {
             self._default_matrix_inplace(t, y);
         }
     }
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.0.mass_sparsity.as_ref().map(|s| s.clone())
+    }
 }
 
-impl<'a, M: Matrix<T = T>, CG: CodegenModule> OdeEquations for DiffSl<'a, M, CG> {
+impl<M: Matrix<T = T>, CG: CodegenModule> Op for DiffSl<M, CG> {
     type M = M;
     type T = T;
     type V = M::V;
-    type Mass = DiffSlMass<'a, M, CG>;
-    type Rhs = DiffSlRhs<'a, M, CG>;
-    type Root = DiffSlRoot<'a, M, CG>;
-    type Init = DiffSlInit<'a, M, CG>;
-    type Out = DiffSlOut<'a, M, CG>;
 
-    fn rhs(&self) -> &Rc<Self::Rhs> {
-        &self.rhs
+    fn nstates(&self) -> usize {
+        self.context.nstates
     }
-
-    fn mass(&self) -> Option<&Rc<Self::Mass>> {
-        self.mass.as_ref()
+    fn nout(&self) -> usize {
+        self.context.nout
     }
-
-    fn root(&self) -> Option<&Rc<Self::Root>> {
-        Some(&self.root)
+    fn nparams(&self) -> usize {
+        self.context.nparams
     }
-
-    fn set_params(&mut self, p: Self::V) {
+    fn set_params(&mut self, p: Rc<Self::V>) {
         // set the parameters in data
         self.context
             .compiler
@@ -449,24 +376,48 @@ impl<'a, M: Matrix<T = T>, CG: CodegenModule> OdeEquations for DiffSl<'a, M, CG>
             self.context.data.borrow_mut().as_mut_slice(),
         );
     }
+}
 
-    fn init(&self) -> &Rc<Self::Init> {
-        &self.init
+impl<'a, M: Matrix<T = T>, CG: CodegenModule> OdeEquationsRef<'a> for DiffSl<M, CG> {
+    type Mass = DiffSlMass<'a, M, CG>;
+    type Rhs = DiffSlRhs<'a, M, CG>;
+    type Root = DiffSlRoot<'a, M, CG>;
+    type Init = DiffSlInit<'a, M, CG>;
+    type Out = DiffSlOut<'a, M, CG>;
+}
+
+impl<M: Matrix<T = T>, CG: CodegenModule> OdeEquations for DiffSl<M, CG> {
+    fn rhs(&self) -> DiffSlRhs<'_, M, CG> {
+        DiffSlRhs(self)
     }
 
-    fn out(&self) -> Option<&Rc<Self::Out>> {
-        Some(&self.out)
+    fn mass(&self) -> Option<DiffSlMass<'_, M, CG>> {
+        Some(DiffSlMass(self))
+    }
+
+    fn root(&self) -> Option<DiffSlRoot<'_, M, CG>> {
+        Some(DiffSlRoot(self))
+    }
+
+    fn init(&self) -> DiffSlInit<'_, M, CG> {
+        DiffSlInit(self)
+    }
+
+    fn out(&self) -> Option<DiffSlOut<'_, M, CG>> {
+        Some(DiffSlOut(self))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use diffsl::{execution::module::CodegenModule, CraneliftModule};
     use nalgebra::DVector;
 
     use crate::{
         Bdf, ConstantOp, LinearOp, NonLinearOp, NonLinearOpJacobian, OdeBuilder, OdeEquations,
-        OdeSolverMethod, OdeSolverState, Vector,
+        OdeSolverMethod, OdeSolverState, Vector, Op
     };
 
     use super::{DiffSl, DiffSlContext};
@@ -481,6 +432,7 @@ mod tests {
     fn diffsl_logistic_growth_llvm() {
         diffsl_logistic_growth::<diffsl::LlvmModule>();
     }
+    
 
     fn diffsl_logistic_growth<CG: CodegenModule>() {
         let text = "
@@ -512,9 +464,9 @@ mod tests {
         let k = 1.0;
         let r = 1.0;
         let context = DiffSlContext::<nalgebra::DMatrix<f64>, CG>::new(text).unwrap();
-        let mut eqn = DiffSl::new(&context, false);
+        let mut eqn = DiffSl::from_context(context);
         let p = DVector::from_vec(vec![r, k]);
-        eqn.set_params(p);
+        eqn.set_params(Rc::new(p));
 
         // test that the initial values look ok
         let y0 = 0.1;
@@ -535,7 +487,7 @@ mod tests {
         mass_y.assert_eq_st(&mass_y_expect, 1e-10);
 
         // solver a bit and check the state and output
-        let problem = OdeBuilder::new().p([r, k]).build_diffsl(&context).unwrap();
+        let problem = OdeBuilder::new().p([r, k]).build_from_eqn(eqn).unwrap();
         let mut solver = Bdf::default();
         let t = 1.0;
         let state = OdeSolverState::new(&problem, &solver).unwrap();

--- a/src/ode_solver/diffsl.rs
+++ b/src/ode_solver/diffsl.rs
@@ -59,7 +59,7 @@ pub struct DiffSlContext<M: Matrix<T = T>, CG: CodegenModule> {
 
 impl<M: Matrix<T = T>, CG: CodegenModule> DiffSlContext<M, CG> {
     /// Create a new context for the ODE equations specified using the [DiffSL language](https://martinjrobins.github.io/diffsl/).
-    /// The input parameters are not initialized and must be set using the [OdeEquations::set_params] function before solving the ODE.
+    /// The input parameters are not initialized and must be set using the [Op::set_params] function before solving the ODE.
     pub fn new(text: &str) -> Result<Self, DiffsolError> {
         let compiler =
             Compiler::from_discrete_str(text).map_err(|e| DiffsolError::Other(e.to_string()))?;

--- a/src/ode_solver/equations.rs
+++ b/src/ode_solver/equations.rs
@@ -163,13 +163,13 @@ impl<Eqn: OdeEquationsImplicit> AugmentedOdeEquations<Eqn> for NoAug<Eqn> {
 /// $$
 ///
 /// The ODE equations are defined by:
-/// - the right-hand side function `F(t, y)`, which is given as a [NonLinearOp] using the `Rhs` associated type and [Self::rhs] function,
-/// - the initial condition `y_0(t_0)`, which is given using the [Self::init] function.
+/// - the right-hand side function `F(t, y)`, which is given as a [NonLinearOp] using the `Rhs` associated type and [OdeEquations::rhs] function,
+/// - the initial condition `y_0(t_0)`, which is given as a [ConstantOp] using the `Init` associated type and [OdeEquations::init] function.
 ///
 /// Optionally, the ODE equations can also include:
-/// - the mass matrix `M` which is given as a [LinearOp] using the `Mass` associated type and the [Self::mass] function,
-/// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [Self::root] function
-/// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [Self::out] function
+/// - the mass matrix `M` which is given as a [LinearOp] using the `Mass` associated type and the [OdeEquations::mass] function,
+/// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [OdeEquations::root] function
+/// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [OdeEquations::out] function
 pub trait OdeEquationsRef<'a, ImplicitBounds: Sealed = Bounds<&'a Self>>: Op {
     type Mass: LinearOp<M = Self::M, V = Self::V, T = Self::T>;
     type Rhs: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
@@ -194,13 +194,13 @@ use sealed::{Bounds, Sealed};
 /// $$
 ///
 /// The ODE equations are defined by:
-/// - the right-hand side function `F(t, y)`, which is given as a [NonLinearOp] using the `Rhs` associated type and [Self::rhs] function,
-/// - the initial condition `y_0(t_0)`, which is given using the [Self::init] function.
+/// - the right-hand side function `F(t, y)`, which is given as a [NonLinearOp] using the `Rhs` associated type and [OdeEquations::rhs] function,
+/// - the initial condition `y_0(t_0)`, which is given as a [ConstantOp] using the `Init` associated type and [OdeEquations::init] function.
 ///
 /// Optionally, the ODE equations can also include:
-/// - the mass matrix `M` which is given as a [LinearOp] using the `Mass` associated type and the [Self::mass] function,
-/// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [Self::root] function
-/// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [Self::out] function
+/// - the mass matrix `M` which is given as a [LinearOp] using the `Mass` associated type and the [OdeEquations::mass] function,
+/// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [OdeEquations::root] function
+/// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [OdeEquations::out] function
 pub trait OdeEquations: for<'a> OdeEquationsRef<'a> {
     /// returns the right-hand side function `F(t, y)` as a [NonLinearOp]
     fn rhs(&self) -> <Self as OdeEquationsRef<'_>>::Rhs;

--- a/src/ode_solver/equations.rs
+++ b/src/ode_solver/equations.rs
@@ -1,7 +1,9 @@
 use std::rc::Rc;
 
 use crate::{
-    op::{constant_op::ConstantOpSensAdjoint, linear_op::LinearOpTranspose}, ConstantOp, ConstantOpSens, LinearOp, Matrix, NonLinearOp, NonLinearOpAdjoint, NonLinearOpJacobian, NonLinearOpSens, NonLinearOpSensAdjoint, Op, UnitCallable
+    op::{constant_op::ConstantOpSensAdjoint, linear_op::LinearOpTranspose},
+    ConstantOp, ConstantOpSens, LinearOp, Matrix, NonLinearOp, NonLinearOpAdjoint,
+    NonLinearOpJacobian, NonLinearOpSens, NonLinearOpSensAdjoint, Op, UnitCallable,
 };
 use serde::Serialize;
 
@@ -63,14 +65,14 @@ pub struct NoAug<Eqn: OdeEquations> {
     _phantom: std::marker::PhantomData<Eqn>,
 }
 
-impl<Eqn> Op for NoAug<Eqn> 
-where 
-    Eqn: OdeEquations
+impl<Eqn> Op for NoAug<Eqn>
+where
+    Eqn: OdeEquations,
 {
     type T = Eqn::T;
     type V = Eqn::V;
     type M = Eqn::M;
-    
+
     fn nout(&self) -> usize {
         panic!("This should never be called")
     }
@@ -178,12 +180,11 @@ pub trait OdeEquationsRef<'a, ImplicitBounds: Sealed = Bounds<&'a Self>>: Op {
 
 // seal the trait so that users must use the provided default type for ImplicitBounds
 mod sealed {
-	pub trait Sealed: Sized {}
-	pub struct Bounds<T>(T);
-	impl<T> Sealed for Bounds<T> {}
+    pub trait Sealed: Sized {}
+    pub struct Bounds<T>(T);
+    impl<T> Sealed for Bounds<T> {}
 }
 use sealed::{Bounds, Sealed};
-
 
 /// this is the trait that defines the ODE equations of the form
 ///
@@ -201,7 +202,6 @@ use sealed::{Bounds, Sealed};
 /// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [Self::root] function
 /// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [Self::out] function
 pub trait OdeEquations: for<'a> OdeEquationsRef<'a> {
-
     /// returns the right-hand side function `F(t, y)` as a [NonLinearOp]
     fn rhs(&self) -> <Self as OdeEquationsRef<'_>>::Rhs;
 
@@ -234,9 +234,9 @@ impl<T> OdeEquationsImplicit for T where
 
 pub trait OdeEquationsSens:
     OdeEquationsImplicit<
-        Rhs: NonLinearOpSens<M = Self::M, V = Self::V, T = Self::T>,
-        Init: ConstantOpSens<M = Self::M, V = Self::V, T = Self::T>,
-    >
+    Rhs: NonLinearOpSens<M = Self::M, V = Self::V, T = Self::T>,
+    Init: ConstantOpSens<M = Self::M, V = Self::V, T = Self::T>,
+>
 {
 }
 
@@ -386,15 +386,14 @@ where
     }
 }
 
-impl<M, Rhs, Init, Mass, Root, Out> Op for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out> 
-where 
+impl<M, Rhs, Init, Mass, Root, Out> Op for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out>
+where
     M: Matrix,
     Init: Op<M = M, V = M::V, T = M::T>,
     Rhs: Op<M = M, V = M::V, T = M::T>,
     Mass: Op<M = M, V = M::V, T = M::T>,
     Root: Op<M = M, V = M::V, T = M::T>,
     Out: Op<M = M, V = M::V, T = M::T>,
-
 {
     type T = M::T;
     type V = M::V;
@@ -428,7 +427,8 @@ where
     }
 }
 
-impl<'a, M, Rhs, Init, Mass, Root, Out> OdeEquationsRef<'a> for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out> 
+impl<'a, M, Rhs, Init, Mass, Root, Out> OdeEquationsRef<'a>
+    for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out>
 where
     M: Matrix,
     Rhs: NonLinearOp<M = M, V = M::V, T = M::T>,
@@ -443,7 +443,6 @@ where
     type Init = &'a Init;
     type Out = &'a Out;
 }
-
 
 impl<M, Rhs, Init, Mass, Root, Out> OdeEquations
     for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out>

--- a/src/ode_solver/equations.rs
+++ b/src/ode_solver/equations.rs
@@ -1,9 +1,7 @@
 use std::rc::Rc;
 
 use crate::{
-    op::{constant_op::ConstantOpSensAdjoint, linear_op::LinearOpTranspose},
-    ConstantOp, ConstantOpSens, LinearOp, Matrix, NonLinearOp, NonLinearOpAdjoint,
-    NonLinearOpJacobian, NonLinearOpSens, NonLinearOpSensAdjoint, Scalar, UnitCallable, Vector,
+    op::{constant_op::ConstantOpSensAdjoint, linear_op::LinearOpTranspose}, ConstantOp, ConstantOpSens, LinearOp, Matrix, NonLinearOp, NonLinearOpAdjoint, NonLinearOpJacobian, NonLinearOpSens, NonLinearOpSensAdjoint, Op, UnitCallable
 };
 use serde::Serialize;
 
@@ -49,7 +47,7 @@ pub trait AugmentedOdeEquations<Eqn: OdeEquations>:
     fn out_atol(&self) -> Option<&Rc<Eqn::V>>;
 }
 
-pub trait AugmentedOdeEquationsImplicit<Eqn: OdeEquations>:
+pub trait AugmentedOdeEquationsImplicit<Eqn: OdeEquationsImplicit>:
     AugmentedOdeEquations<Eqn> + OdeEquationsImplicit<T = Eqn::T, V = Eqn::V, M = Eqn::M>
 {
 }
@@ -57,7 +55,7 @@ pub trait AugmentedOdeEquationsImplicit<Eqn: OdeEquations>:
 impl<Aug, Eqn> AugmentedOdeEquationsImplicit<Eqn> for Aug
 where
     Aug: AugmentedOdeEquations<Eqn> + OdeEquationsImplicit<T = Eqn::T, V = Eqn::V, M = Eqn::M>,
-    Eqn: OdeEquations,
+    Eqn: OdeEquationsImplicit,
 {
 }
 
@@ -65,42 +63,63 @@ pub struct NoAug<Eqn: OdeEquations> {
     _phantom: std::marker::PhantomData<Eqn>,
 }
 
-impl<Eqn: OdeEquations> OdeEquations for NoAug<Eqn> {
+impl<Eqn> Op for NoAug<Eqn> 
+where 
+    Eqn: OdeEquations
+{
     type T = Eqn::T;
     type V = Eqn::V;
     type M = Eqn::M;
-    type Mass = Eqn::Mass;
-    type Rhs = Eqn::Rhs;
-    type Root = Eqn::Root;
-    type Init = Eqn::Init;
-    type Out = Eqn::Out;
-
-    fn set_params(&mut self, _p: Self::V) {
+    
+    fn nout(&self) -> usize {
+        panic!("This should never be called")
+    }
+    fn nparams(&self) -> usize {
+        panic!("This should never be called")
+    }
+    fn nstates(&self) -> usize {
+        panic!("This should never be called")
+    }
+    fn statistics(&self) -> crate::op::OpStatistics {
         panic!("This should never be called")
     }
 
-    fn rhs(&self) -> &Rc<Self::Rhs> {
-        panic!("This should never be called")
-    }
-
-    fn mass(&self) -> Option<&Rc<Self::Mass>> {
-        panic!("This should never be called")
-    }
-
-    fn root(&self) -> Option<&Rc<Self::Root>> {
-        panic!("This should never be called")
-    }
-
-    fn out(&self) -> Option<&Rc<Self::Out>> {
-        panic!("This should never be called")
-    }
-
-    fn init(&self) -> &Rc<Self::Init> {
+    fn set_params(&mut self, _p: Rc<Self::V>) {
         panic!("This should never be called")
     }
 }
 
-impl<Eqn: OdeEquations> AugmentedOdeEquations<Eqn> for NoAug<Eqn> {
+impl<'a, Eqn: OdeEquations> OdeEquationsRef<'a> for NoAug<Eqn> {
+    type Mass = <Eqn as OdeEquationsRef<'a>>::Mass;
+    type Rhs = <Eqn as OdeEquationsRef<'a>>::Rhs;
+    type Root = <Eqn as OdeEquationsRef<'a>>::Root;
+    type Init = <Eqn as OdeEquationsRef<'a>>::Init;
+    type Out = <Eqn as OdeEquationsRef<'a>>::Out;
+}
+
+impl<Eqn: OdeEquations> OdeEquations for NoAug<Eqn> {
+    fn rhs(&self) -> <Self as OdeEquationsRef<'_>>::Rhs {
+        panic!("This should never be called")
+    }
+
+    fn mass(&self) -> Option<<Self as OdeEquationsRef<'_>>::Mass> {
+        panic!("This should never be called")
+    }
+
+    fn root(&self) -> Option<<Self as OdeEquationsRef<'_>>::Root> {
+        panic!("This should never be called")
+    }
+
+    fn out(&self) -> Option<<Self as OdeEquationsRef<'_>>::Out> {
+        panic!("This should never be called")
+    }
+
+    fn init(&self) -> <Self as OdeEquationsRef<'_>>::Init {
+        panic!("This should never be called")
+    }
+}
+
+impl<Eqn: OdeEquationsImplicit> AugmentedOdeEquations<Eqn> for NoAug<Eqn> {
     fn update_rhs_out_state(&mut self, _y: &Eqn::V, _dy: &Eqn::V, _t: Eqn::T) {
         panic!("This should never be called")
     }
@@ -110,19 +129,19 @@ impl<Eqn: OdeEquations> AugmentedOdeEquations<Eqn> for NoAug<Eqn> {
     fn set_index(&mut self, _index: usize) {
         panic!("This should never be called")
     }
-    fn atol(&self) -> Option<&Rc<<Eqn as OdeEquations>::V>> {
+    fn atol(&self) -> Option<&Rc<<Eqn as Op>::V>> {
         panic!("This should never be called")
     }
     fn include_out_in_error_control(&self) -> bool {
         panic!("This should never be called")
     }
-    fn out_atol(&self) -> Option<&Rc<<Eqn as OdeEquations>::V>> {
+    fn out_atol(&self) -> Option<&Rc<<Eqn as Op>::V>> {
         panic!("This should never be called")
     }
-    fn out_rtol(&self) -> Option<<Eqn as OdeEquations>::T> {
+    fn out_rtol(&self) -> Option<<Eqn as Op>::T> {
         panic!("This should never be called")
     }
-    fn rtol(&self) -> Option<<Eqn as OdeEquations>::T> {
+    fn rtol(&self) -> Option<<Eqn as Op>::T> {
         panic!("This should never be called")
     }
     fn max_index(&self) -> usize {
@@ -132,6 +151,39 @@ impl<Eqn: OdeEquations> AugmentedOdeEquations<Eqn> for NoAug<Eqn> {
         panic!("This should never be called")
     }
 }
+
+/// this is the reference trait that defines the ODE equations of the form, this is used to define the ODE equations for a given lifetime.
+/// See [OdeEquations] for the main trait that defines the ODE equations.
+///
+/// $$
+///  M \frac{dy}{dt} = F(t, y)
+///  y(t_0) = y_0(t_0)
+/// $$
+///
+/// The ODE equations are defined by:
+/// - the right-hand side function `F(t, y)`, which is given as a [NonLinearOp] using the `Rhs` associated type and [Self::rhs] function,
+/// - the initial condition `y_0(t_0)`, which is given using the [Self::init] function.
+///
+/// Optionally, the ODE equations can also include:
+/// - the mass matrix `M` which is given as a [LinearOp] using the `Mass` associated type and the [Self::mass] function,
+/// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [Self::root] function
+/// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [Self::out] function
+pub trait OdeEquationsRef<'a, ImplicitBounds: Sealed = Bounds<&'a Self>>: Op {
+    type Mass: LinearOp<M = Self::M, V = Self::V, T = Self::T>;
+    type Rhs: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
+    type Root: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
+    type Init: ConstantOp<M = Self::M, V = Self::V, T = Self::T>;
+    type Out: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
+}
+
+// seal the trait so that users must use the provided default type for ImplicitBounds
+mod sealed {
+	pub trait Sealed: Sized {}
+	pub struct Bounds<T>(T);
+	impl<T> Sealed for Bounds<T> {}
+}
+use sealed::{Bounds, Sealed};
+
 
 /// this is the trait that defines the ODE equations of the form
 ///
@@ -148,38 +200,26 @@ impl<Eqn: OdeEquations> AugmentedOdeEquations<Eqn> for NoAug<Eqn> {
 /// - the mass matrix `M` which is given as a [LinearOp] using the `Mass` associated type and the [Self::mass] function,
 /// - the root function `G(t, y)` which is given as a [NonLinearOp] using the `Root` associated type and the [Self::root] function
 /// - the output function `H(t, y)` which is given as a [NonLinearOp] using the `Out` associated type and the [Self::out] function
-pub trait OdeEquations {
-    type T: Scalar;
-    type V: Vector<T = Self::T>;
-    type M: Matrix<T = Self::T, V = Self::V>;
-    type Mass: LinearOp<M = Self::M, V = Self::V, T = Self::T>;
-    type Rhs: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
-    type Root: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
-    type Init: ConstantOp<M = Self::M, V = Self::V, T = Self::T>;
-    type Out: NonLinearOp<M = Self::M, V = Self::V, T = Self::T>;
-
-    /// The parameters of the ODE equations are assumed to be constant. This function sets the parameters to the given value before solving the ODE.
-    /// Note that `set_params` must always be called before calling any of the other functions in this trait.
-    fn set_params(&mut self, p: Self::V);
+pub trait OdeEquations: for<'a> OdeEquationsRef<'a> {
 
     /// returns the right-hand side function `F(t, y)` as a [NonLinearOp]
-    fn rhs(&self) -> &Rc<Self::Rhs>;
+    fn rhs(&self) -> <Self as OdeEquationsRef<'_>>::Rhs;
 
     /// returns the mass matrix `M` as a [LinearOp]
-    fn mass(&self) -> Option<&Rc<Self::Mass>>;
+    fn mass(&self) -> Option<<Self as OdeEquationsRef<'_>>::Mass>;
 
     /// returns the root function `G(t, y)` as a [NonLinearOp]
-    fn root(&self) -> Option<&Rc<Self::Root>> {
+    fn root(&self) -> Option<<Self as OdeEquationsRef<'_>>::Root> {
         None
     }
 
     /// returns the output function `H(t, y)` as a [NonLinearOp]
-    fn out(&self) -> Option<&Rc<Self::Out>> {
+    fn out(&self) -> Option<<Self as OdeEquationsRef<'_>>::Out> {
         None
     }
 
     /// returns the initial condition, i.e. `y(t)`, where `t` is the initial time
-    fn init(&self) -> &Rc<Self::Init>;
+    fn init(&self) -> <Self as OdeEquationsRef<'_>>::Init;
 }
 
 pub trait OdeEquationsImplicit:
@@ -194,9 +234,9 @@ impl<T> OdeEquationsImplicit for T where
 
 pub trait OdeEquationsSens:
     OdeEquationsImplicit<
-    Rhs: NonLinearOpSens<M = Self::M, V = Self::V, T = Self::T>,
-    Init: ConstantOpSens<M = Self::M, V = Self::V, T = Self::T>,
->
+        Rhs: NonLinearOpSens<M = Self::M, V = Self::V, T = Self::T>,
+        Init: ConstantOpSens<M = Self::M, V = Self::V, T = Self::T>,
+    >
 {
 }
 
@@ -313,36 +353,26 @@ pub struct OdeSolverEquations<
     Out = UnitCallable<M>,
 > where
     M: Matrix,
-    Rhs: NonLinearOp<M = M, V = M::V, T = M::T>,
-    Mass: LinearOp<M = M, V = M::V, T = M::T>,
-    Root: NonLinearOp<M = M, V = M::V, T = M::T>,
-    Init: ConstantOp<M = M, V = M::V, T = M::T>,
-    Out: NonLinearOp<M = M, V = M::V, T = M::T>,
 {
-    rhs: Rc<Rhs>,
-    mass: Option<Rc<Mass>>,
-    root: Option<Rc<Root>>,
-    init: Rc<Init>,
-    out: Option<Rc<Out>>,
+    rhs: Rhs,
+    mass: Option<Mass>,
+    root: Option<Root>,
+    init: Init,
+    out: Option<Out>,
     p: Rc<M::V>,
 }
 
 impl<M, Rhs, Init, Mass, Root, Out> OdeSolverEquations<M, Rhs, Init, Mass, Root, Out>
 where
     M: Matrix,
-    Rhs: NonLinearOp<M = M, V = M::V, T = M::T>,
-    Mass: LinearOp<M = M, V = M::V, T = M::T>,
-    Root: NonLinearOp<M = M, V = M::V, T = M::T>,
-    Init: ConstantOp<M = M, V = M::V, T = M::T>,
-    Out: NonLinearOp<M = M, V = M::V, T = M::T>,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        rhs: Rc<Rhs>,
-        mass: Option<Rc<Mass>>,
-        root: Option<Rc<Root>>,
-        init: Rc<Init>,
-        out: Option<Rc<Out>>,
+        rhs: Rhs,
+        mass: Option<Mass>,
+        root: Option<Root>,
+        init: Init,
+        out: Option<Out>,
         p: Rc<M::V>,
     ) -> Self {
         Self {
@@ -356,6 +386,47 @@ where
     }
 }
 
+impl<M, Rhs, Init, Mass, Root, Out> Op for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out> 
+where 
+    M: Matrix,
+    Init: Op<M = M, V = M::V, T = M::T>,
+    Rhs: Op<M = M, V = M::V, T = M::T>,
+
+{
+    type T = M::T;
+    type V = M::V;
+    type M = M;
+    fn nstates(&self) -> usize {
+        self.init.nstates()
+    }
+    fn nout(&self) -> usize {
+        self.rhs.nout()
+    }
+    fn nparams(&self) -> usize {
+        self.rhs.nparams()
+    }
+    fn statistics(&self) -> crate::op::OpStatistics {
+        self.rhs.statistics()
+    }
+}
+
+impl<'a, M, Rhs, Init, Mass, Root, Out> OdeEquationsRef<'a> for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out> 
+where
+    M: Matrix,
+    Rhs: NonLinearOp<M = M, V = M::V, T = M::T>,
+    Mass: LinearOp<M = M, V = M::V, T = M::T>,
+    Root: NonLinearOp<M = M, V = M::V, T = M::T>,
+    Init: ConstantOp<M = M, V = M::V, T = M::T>,
+    Out: NonLinearOp<M = M, V = M::V, T = M::T>,
+{
+    type Rhs = &'a Rhs;
+    type Mass = &'a Mass;
+    type Root = &'a Root;
+    type Init = &'a Init;
+    type Out = &'a Out;
+}
+
+
 impl<M, Rhs, Init, Mass, Root, Out> OdeEquations
     for OdeSolverEquations<M, Rhs, Init, Mass, Root, Out>
 where
@@ -366,46 +437,21 @@ where
     Init: ConstantOp<M = M, V = M::V, T = M::T>,
     Out: NonLinearOp<M = M, V = M::V, T = M::T>,
 {
-    type T = M::T;
-    type V = M::V;
-    type M = M;
-    type Rhs = Rhs;
-    type Mass = Mass;
-    type Root = Root;
-    type Init = Init;
-    type Out = Out;
-
-    fn rhs(&self) -> &Rc<Self::Rhs> {
+    fn rhs(&self) -> &Rhs {
         &self.rhs
     }
-    fn mass(&self) -> Option<&Rc<Self::Mass>> {
+    fn mass(&self) -> Option<&Mass> {
         self.mass.as_ref()
     }
-    fn root(&self) -> Option<&Rc<Self::Root>> {
+    fn root(&self) -> Option<&Root> {
         self.root.as_ref()
     }
-    fn init(&self) -> &Rc<Self::Init> {
+    fn init(&self) -> &Init {
         &self.init
     }
 
-    fn out(&self) -> Option<&Rc<Self::Out>> {
+    fn out(&self) -> Option<&Out> {
         self.out.as_ref()
-    }
-
-    fn set_params(&mut self, p: Self::V) {
-        self.p = Rc::new(p);
-        Rc::<Rhs>::get_mut(&mut self.rhs)
-            .unwrap()
-            .set_params(self.p.clone());
-        if let Some(m) = self.mass.as_mut() {
-            Rc::<Mass>::get_mut(m).unwrap().set_params(self.p.clone());
-        }
-        if let Some(r) = self.root.as_mut() {
-            Rc::<Root>::get_mut(r).unwrap().set_params(self.p.clone())
-        }
-        if let Some(o) = self.out.as_mut() {
-            Rc::<Out>::get_mut(o).unwrap().set_params(self.p.clone())
-        }
     }
 }
 

--- a/src/ode_solver/equations.rs
+++ b/src/ode_solver/equations.rs
@@ -332,7 +332,7 @@ impl<T> OdeEquationsAdjoint for T where
 /// let p = Rc::new(V::from_vec(vec![]));
 /// let eqn = OdeSolverEquations::new(rhs, mass, root, init, out, p);
 ///
-/// let problem = OdeBuilder::new().build_from_eqn(Rc::new(eqn)).unwrap();
+/// let problem = OdeBuilder::new().build_from_eqn(eqn).unwrap();
 ///
 /// let mut solver = Bdf::default();
 /// let t = 0.4;

--- a/src/ode_solver/method.rs
+++ b/src/ode_solver/method.rs
@@ -397,7 +397,6 @@ where
 pub trait AugmentedOdeSolverMethod<Eqn, AugmentedEqn>: OdeSolverMethod<Eqn>
 where
     Eqn: OdeEquations,
-    AugmentedEqn: AugmentedOdeEquations<Eqn>,
 {
     fn set_augmented_problem(
         &mut self,
@@ -410,7 +409,7 @@ where
 pub trait SensitivitiesOdeSolverMethod<Eqn>:
     AugmentedOdeSolverMethod<Eqn, SensEquations<Eqn>>
 where
-    Eqn: OdeEquationsSens,
+    Eqn: OdeEquationsSens
 {
     fn set_problem_with_sensitivities(
         &mut self,
@@ -424,7 +423,7 @@ where
 
 pub trait AdjointOdeSolverMethod<Eqn>: OdeSolverMethod<Eqn>
 where
-    Eqn: OdeEquationsAdjoint,
+    Eqn: OdeEquationsAdjoint
 {
     type AdjointSolver: AugmentedOdeSolverMethod<
         AdjointEquations<Eqn, Self>,

--- a/src/ode_solver/method.rs
+++ b/src/ode_solver/method.rs
@@ -6,7 +6,7 @@ use crate::{
     matrix::default_solver::DefaultSolver,
     ode_solver_error,
     scalar::Scalar,
-    AdjointContext, AdjointEquations, AugmentedOdeEquations, Checkpointing, DefaultDenseMatrix,
+    AdjointContext, AdjointEquations, Checkpointing, DefaultDenseMatrix,
     DenseMatrix, Matrix, NewtonNonlinearSolver, NonLinearOp, OdeEquations, OdeEquationsAdjoint,
     OdeEquationsSens, OdeSolverProblem, OdeSolverState, Op, SensEquations, StateRef, StateRefMut,
     Vector, VectorViewMut,

--- a/src/ode_solver/method.rs
+++ b/src/ode_solver/method.rs
@@ -6,10 +6,10 @@ use crate::{
     matrix::default_solver::DefaultSolver,
     ode_solver_error,
     scalar::Scalar,
-    AdjointContext, AdjointEquations, Checkpointing, DefaultDenseMatrix,
-    DenseMatrix, Matrix, NewtonNonlinearSolver, NonLinearOp, OdeEquations, OdeEquationsAdjoint,
-    OdeEquationsSens, OdeSolverProblem, OdeSolverState, Op, SensEquations, StateRef, StateRefMut,
-    Vector, VectorViewMut,
+    AdjointContext, AdjointEquations, Checkpointing, DefaultDenseMatrix, DenseMatrix, Matrix,
+    NewtonNonlinearSolver, NonLinearOp, OdeEquations, OdeEquationsAdjoint, OdeEquationsSens,
+    OdeSolverProblem, OdeSolverState, Op, SensEquations, StateRef, StateRefMut, Vector,
+    VectorViewMut,
 };
 
 use super::checkpointing::HermiteInterpolator;
@@ -409,7 +409,7 @@ where
 pub trait SensitivitiesOdeSolverMethod<Eqn>:
     AugmentedOdeSolverMethod<Eqn, SensEquations<Eqn>>
 where
-    Eqn: OdeEquationsSens
+    Eqn: OdeEquationsSens,
 {
     fn set_problem_with_sensitivities(
         &mut self,
@@ -423,7 +423,7 @@ where
 
 pub trait AdjointOdeSolverMethod<Eqn>: OdeSolverMethod<Eqn>
 where
-    Eqn: OdeEquationsAdjoint
+    Eqn: OdeEquationsAdjoint,
 {
     type AdjointSolver: AugmentedOdeSolverMethod<
         AdjointEquations<Eqn, Self>,

--- a/src/ode_solver/mod.rs
+++ b/src/ode_solver/mod.rs
@@ -455,9 +455,9 @@ mod tests {
 
     pub fn test_interpolate<M: Matrix, Method: OdeSolverMethod<TestEqn<M>>>(mut s: Method) {
         let problem = OdeSolverProblem::new(
-            TestEqn::new(),
+            Rc::new(TestEqn::new()),
             M::T::from(1e-6),
-            M::V::from_element(1, M::T::from(1e-6)),
+            Rc::new(M::V::from_element(1, M::T::from(1e-6))),
             None,
             None,
             None,
@@ -492,9 +492,9 @@ mod tests {
 
     pub fn test_state_mut<M: Matrix, Method: OdeSolverMethod<TestEqn<M>>>(mut s: Method) {
         let problem = OdeSolverProblem::new(
-            TestEqn::new(),
+            Rc::new(TestEqn::new()),
             M::T::from(1e-6),
-            M::V::from_element(1, M::T::from(1e-6)),
+            Rc::new(M::V::from_element(1, M::T::from(1e-6))),
             None,
             None,
             None,

--- a/src/ode_solver/mod.rs
+++ b/src/ode_solver/mod.rs
@@ -32,12 +32,12 @@ mod tests {
     use super::*;
     use crate::matrix::Matrix;
     use crate::op::unit::UnitCallable;
-    use crate::{ConstantOp, DefaultDenseMatrix, DefaultSolver, NonLinearOp, Op, Vector};
     use crate::{
-        NonLinearOpJacobian, OdeEquations, OdeEquationsAdjoint, OdeEquationsImplicit,
-        OdeEquationsSens, OdeSolverMethod, OdeSolverProblem, OdeSolverState, OdeSolverStopReason,
-        OdeEquationsRef, op::OpStatistics,
+        op::OpStatistics, NonLinearOpJacobian, OdeEquations, OdeEquationsAdjoint,
+        OdeEquationsImplicit, OdeEquationsRef, OdeEquationsSens, OdeSolverMethod, OdeSolverProblem,
+        OdeSolverState, OdeSolverStopReason,
     };
+    use crate::{ConstantOp, DefaultDenseMatrix, DefaultSolver, NonLinearOp, Op, Vector};
     use num_traits::One;
     use num_traits::Zero;
 
@@ -451,7 +451,6 @@ mod tests {
             None
         }
     }
-
 
     pub fn test_interpolate<M: Matrix, Method: OdeSolverMethod<TestEqn<M>>>(mut s: Method) {
         let problem = OdeSolverProblem::new(

--- a/src/ode_solver/problem.rs
+++ b/src/ode_solver/problem.rs
@@ -94,7 +94,7 @@ impl<Eqn: OdeEquations> OdeSolverProblem<Eqn> {
     pub fn set_params(&mut self, p: Eqn::V) -> Result<(), DiffsolError> {
         let eqn =
             Rc::get_mut(&mut self.eqn).ok_or(ode_solver_error!(FailedToGetMutableReference))?;
-        eqn.set_params(p);
+        eqn.set_params(Rc::new(p));
         Ok(())
     }
 }

--- a/src/ode_solver/problem.rs
+++ b/src/ode_solver/problem.rs
@@ -57,24 +57,19 @@ impl<Eqn: OdeEquations> OdeSolverProblem<Eqn> {
     }
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        eqn: Eqn,
+        eqn: Rc<Eqn>,
         rtol: Eqn::T,
-        atol: Eqn::V,
+        atol: Rc<Eqn::V>,
         sens_rtol: Option<Eqn::T>,
-        sens_atol: Option<Eqn::V>,
+        sens_atol: Option<Rc<Eqn::V>>,
         out_rtol: Option<Eqn::T>,
-        out_atol: Option<Eqn::V>,
+        out_atol: Option<Rc<Eqn::V>>,
         param_rtol: Option<Eqn::T>,
-        param_atol: Option<Eqn::V>,
+        param_atol: Option<Rc<Eqn::V>>,
         t0: Eqn::T,
         h0: Eqn::T,
         integrate_out: bool,
     ) -> Result<Self, DiffsolError> {
-        let eqn = Rc::new(eqn);
-        let atol = Rc::new(atol);
-        let out_atol = out_atol.map(Rc::new);
-        let param_atol = param_atol.map(Rc::new);
-        let sens_atol = sens_atol.map(Rc::new);
         Ok(Self {
             eqn,
             rtol,

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -533,7 +533,7 @@ where
             self.root_finder
                 .as_ref()
                 .unwrap()
-                .init(root_fn.as_ref(), &state.y, state.t);
+                .init(&root_fn, &state.y, state.t);
         }
         Ok(())
     }
@@ -828,7 +828,7 @@ where
         if let Some(root_fn) = self.problem.as_ref().unwrap().eqn.root() {
             let ret = self.root_finder.as_ref().unwrap().check_root(
                 &|t| self.interpolate(t),
-                root_fn.as_ref(),
+                &root_fn,
                 &self.state.as_ref().unwrap().y,
                 self.state.as_ref().unwrap().t,
             );
@@ -848,7 +848,7 @@ where
         Ok(OdeSolverStopReason::InternalTimestep)
     }
 
-    fn set_stop_time(&mut self, tstop: <Eqn as OdeEquations>::T) -> Result<(), DiffsolError> {
+    fn set_stop_time(&mut self, tstop: <Eqn as Op>::T) -> Result<(), DiffsolError> {
         self.tstop = Some(tstop);
         if let Some(OdeSolverStopReason::TstopReached) = self.handle_tstop(tstop)? {
             let error = OdeSolverError::StopTimeBeforeCurrentTime {
@@ -863,8 +863,8 @@ where
 
     fn interpolate_sens(
         &self,
-        t: <Eqn as OdeEquations>::T,
-    ) -> Result<Vec<<Eqn as OdeEquations>::V>, DiffsolError> {
+        t: <Eqn as Op>::T,
+    ) -> Result<Vec<<Eqn as Op>::V>, DiffsolError> {
         if self.state.is_none() {
             return Err(ode_solver_error!(StateNotSet));
         }

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -23,9 +23,9 @@ use crate::SensEquations;
 use crate::Tableau;
 use crate::{
     nonlinear_solver::NonLinearSolver, op::sdirk::SdirkCallable, scale, AdjointOdeSolverMethod,
-    AugmentedOdeEquations, DenseMatrix, JacobianUpdate, NonLinearOp, 
+    AugmentedOdeEquations, AugmentedOdeEquationsImplicit, DenseMatrix, JacobianUpdate, NonLinearOp,
     OdeEquationsAdjoint, OdeEquationsImplicit, OdeEquationsSens, OdeSolverMethod, OdeSolverProblem,
-    OdeSolverState, Op, Scalar, StateRef, StateRefMut, Vector, VectorViewMut, AugmentedOdeEquationsImplicit
+    OdeSolverState, Op, Scalar, StateRef, StateRefMut, Vector, VectorViewMut,
 };
 
 use super::bdf::BdfStatistics;
@@ -861,10 +861,7 @@ where
         Ok(())
     }
 
-    fn interpolate_sens(
-        &self,
-        t: <Eqn as Op>::T,
-    ) -> Result<Vec<<Eqn as Op>::V>, DiffsolError> {
+    fn interpolate_sens(&self, t: <Eqn as Op>::T) -> Result<Vec<<Eqn as Op>::V>, DiffsolError> {
         if self.state.is_none() {
             return Err(ode_solver_error!(StateNotSet));
         }

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -23,9 +23,9 @@ use crate::SensEquations;
 use crate::Tableau;
 use crate::{
     nonlinear_solver::NonLinearSolver, op::sdirk::SdirkCallable, scale, AdjointOdeSolverMethod,
-    AugmentedOdeEquations, DenseMatrix, JacobianUpdate, NonLinearOp, OdeEquations,
+    AugmentedOdeEquations, DenseMatrix, JacobianUpdate, NonLinearOp, 
     OdeEquationsAdjoint, OdeEquationsImplicit, OdeEquationsSens, OdeSolverMethod, OdeSolverProblem,
-    OdeSolverState, Op, Scalar, StateRef, StateRefMut, Vector, VectorViewMut,
+    OdeSolverState, Op, Scalar, StateRef, StateRefMut, Vector, VectorViewMut, AugmentedOdeEquationsImplicit
 };
 
 use super::bdf::BdfStatistics;
@@ -166,7 +166,7 @@ where
     LS: LinearSolver<Eqn::M>,
     M: DenseMatrix<T = Eqn::T, V = Eqn::V>,
     Eqn: OdeEquationsImplicit,
-    AugmentedEqn: AugmentedOdeEquations<Eqn>,
+    AugmentedEqn: AugmentedOdeEquationsImplicit<Eqn>,
     for<'a> &'a Eqn::V: VectorRef<Eqn::V>,
     for<'a> &'a Eqn::M: MatrixRef<Eqn::M>,
 {
@@ -451,7 +451,7 @@ where
     LS: LinearSolver<Eqn::M>,
     M: DenseMatrix<T = Eqn::T, V = Eqn::V>,
     Eqn: OdeEquationsImplicit,
-    AugmentedEqn: AugmentedOdeEquations<Eqn>,
+    AugmentedEqn: AugmentedOdeEquationsImplicit<Eqn>,
     for<'a> &'a Eqn::V: VectorRef<Eqn::V>,
     for<'a> &'a Eqn::M: MatrixRef<Eqn::M>,
 {
@@ -1007,7 +1007,7 @@ where
     LS: LinearSolver<Eqn::M>,
     M: DenseMatrix<T = Eqn::T, V = Eqn::V>,
     Eqn: OdeEquationsImplicit,
-    AugmentedEqn: AugmentedOdeEquations<Eqn>,
+    AugmentedEqn: AugmentedOdeEquationsImplicit<Eqn>,
     for<'a> &'a Eqn::V: VectorRef<Eqn::V>,
     for<'a> &'a Eqn::M: MatrixRef<Eqn::M>,
 {

--- a/src/ode_solver/sdirk.rs
+++ b/src/ode_solver/sdirk.rs
@@ -1127,7 +1127,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 4
         number_of_steps: 29
         number_of_error_test_failures: 0
@@ -1135,7 +1134,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 118
         number_of_jac_muls: 2
         number_of_matrix_evals: 1
@@ -1149,7 +1147,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 7
         number_of_steps: 52
         number_of_error_test_failures: 0
@@ -1157,7 +1154,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 210
         number_of_jac_muls: 318
         number_of_matrix_evals: 2
@@ -1171,7 +1167,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 3
         number_of_steps: 13
         number_of_error_test_failures: 0
@@ -1179,7 +1174,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 86
         number_of_jac_muls: 2
         number_of_matrix_evals: 1
@@ -1193,7 +1187,6 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 5
         number_of_steps: 20
         number_of_error_test_failures: 0
@@ -1201,7 +1194,6 @@ mod test {
         number_of_nonlinear_solver_fails: 0
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 122
         number_of_jac_muls: 201
         number_of_matrix_evals: 1
@@ -1215,14 +1207,12 @@ mod test {
         let (problem, soln) = exponential_decay_problem_adjoint::<M>();
         let adjoint_solver = test_ode_solver_adjoint(s, &problem, soln);
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
-        ---
         number_of_calls: 196
         number_of_jac_muls: 6
         number_of_matrix_evals: 3
         number_of_jac_adj_muls: 599
         "###);
         insta::assert_yaml_snapshot!(adjoint_solver.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 18
         number_of_steps: 29
         number_of_error_test_failures: 10
@@ -1237,14 +1227,12 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_adjoint_problem::<M>();
         let adjoint_solver = test_ode_solver_adjoint(s, &problem, soln);
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
-        ---
         number_of_calls: 171
         number_of_jac_muls: 12
         number_of_matrix_evals: 4
         number_of_jac_adj_muls: 287
         "###);
         insta::assert_yaml_snapshot!(adjoint_solver.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 18
         number_of_steps: 20
         number_of_error_test_failures: 11
@@ -1259,7 +1247,6 @@ mod test {
         let (problem, soln) = robertson::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 97
         number_of_steps: 232
         number_of_error_test_failures: 0
@@ -1267,7 +1254,6 @@ mod test {
         number_of_nonlinear_solver_fails: 18
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 1924
         number_of_jac_muls: 36
         number_of_matrix_evals: 12
@@ -1281,7 +1267,6 @@ mod test {
         let (problem, soln) = robertson_sens::<M>();
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 112
         number_of_steps: 216
         number_of_error_test_failures: 0
@@ -1289,7 +1274,6 @@ mod test {
         number_of_nonlinear_solver_fails: 37
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 1420
         number_of_jac_muls: 3277
         number_of_matrix_evals: 27
@@ -1303,7 +1287,6 @@ mod test {
         let (problem, soln) = robertson::<M>(false);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 100
         number_of_steps: 141
         number_of_error_test_failures: 0
@@ -1311,7 +1294,6 @@ mod test {
         number_of_nonlinear_solver_fails: 24
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 1796
         number_of_jac_muls: 54
         number_of_matrix_evals: 18
@@ -1325,7 +1307,6 @@ mod test {
         let (problem, soln) = robertson_sens::<M>();
         test_ode_solver(&mut s, &problem, soln, None, false, true);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 114
         number_of_steps: 131
         number_of_error_test_failures: 0
@@ -1333,7 +1314,6 @@ mod test {
         number_of_nonlinear_solver_fails: 44
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 1492
         number_of_jac_muls: 3136
         number_of_matrix_evals: 33
@@ -1347,7 +1327,6 @@ mod test {
         let (problem, soln) = robertson_ode::<M>(false, 1);
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        ---
         number_of_linear_solver_setups: 113
         number_of_steps: 304
         number_of_error_test_failures: 1
@@ -1355,7 +1334,6 @@ mod test {
         number_of_nonlinear_solver_fails: 15
         "###);
         insta::assert_yaml_snapshot!(problem.eqn.as_ref().rhs().statistics(), @r###"
-        ---
         number_of_calls: 2603
         number_of_jac_muls: 39
         number_of_matrix_evals: 13

--- a/src/ode_solver/sens_equations.rs
+++ b/src/ode_solver/sens_equations.rs
@@ -2,7 +2,9 @@ use num_traits::Zero;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{
-    op::nonlinear_op::NonLinearOpJacobian, AugmentedOdeEquations, ConstantOp, ConstantOpSens, Matrix, NonLinearOp, NonLinearOpSens, OdeEquations, OdeEquationsRef, OdeEquationsSens, OdeSolverProblem, Op, Vector,
+    op::nonlinear_op::NonLinearOpJacobian, AugmentedOdeEquations, ConstantOp, ConstantOpSens,
+    Matrix, NonLinearOp, NonLinearOpSens, OdeEquations, OdeEquationsRef, OdeEquationsSens,
+    OdeSolverProblem, Op, Vector,
 };
 
 pub struct SensInit<Eqn>
@@ -21,11 +23,7 @@ where
     pub fn new(eqn: &Rc<Eqn>) -> Self {
         let nstates = eqn.rhs().nstates();
         let nparams = eqn.rhs().nparams();
-        let init_sens = Eqn::M::new_from_sparsity(
-            nstates,
-            nparams,
-            eqn.init().sens_sparsity(),
-        );
+        let init_sens = Eqn::M::new_from_sparsity(nstates, nparams, eqn.init().sens_sparsity());
         let index = 0;
         Self {
             eqn: eqn.clone(),

--- a/src/ode_solver/sens_equations.rs
+++ b/src/ode_solver/sens_equations.rs
@@ -2,7 +2,7 @@ use num_traits::Zero;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{
-    op::nonlinear_op::NonLinearOpJacobian, AugmentedOdeEquations, ConstantOp, ConstantOpSens, Matrix, NonLinearOp, NonLinearOpSens, OdeEquations, OdeEquationsRef, OdeEquationsSens, OdeSolverProblem, Op, Vector
+    op::nonlinear_op::NonLinearOpJacobian, AugmentedOdeEquations, ConstantOp, ConstantOpSens, Matrix, NonLinearOp, NonLinearOpSens, OdeEquations, OdeEquationsRef, OdeEquationsSens, OdeSolverProblem, Op, Vector,
 };
 
 pub struct SensInit<Eqn>

--- a/src/ode_solver/sens_equations.rs
+++ b/src/ode_solver/sens_equations.rs
@@ -2,9 +2,7 @@ use num_traits::Zero;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{
-    matrix::sparsity::MatrixSparsityRef, op::nonlinear_op::NonLinearOpJacobian,
-    AugmentedOdeEquations, ConstantOp, ConstantOpSens, Matrix, NonLinearOp, NonLinearOpSens,
-    OdeEquations, OdeEquationsSens, OdeSolverProblem, Op, Vector,
+    op::nonlinear_op::NonLinearOpJacobian, AugmentedOdeEquations, ConstantOp, ConstantOpSens, Matrix, NonLinearOp, NonLinearOpSens, OdeEquations, OdeEquationsRef, OdeEquationsSens, OdeSolverProblem, Op, Vector
 };
 
 pub struct SensInit<Eqn>
@@ -26,7 +24,7 @@ where
         let init_sens = Eqn::M::new_from_sparsity(
             nstates,
             nparams,
-            eqn.init().sparsity_sens().map(|s| s.to_owned()),
+            eqn.init().sens_sparsity(),
         );
         let index = 0;
         Self {
@@ -113,7 +111,7 @@ where
         let rhs_sens = Eqn::M::new_from_sparsity(
             nstates,
             nparams,
-            eqn.rhs().sparsity_sens().map(|s| s.to_owned()),
+            eqn.rhs().sens_sparsity().map(|s| s.to_owned()),
         );
         let y = RefCell::new(<Eqn::V as Vector>::zeros(nstates));
         let index = RefCell::new(0);
@@ -257,35 +255,34 @@ where
     }
 }
 
+impl<'a, Eqn> OdeEquationsRef<'a> for SensEquations<Eqn>
+where
+    Eqn: OdeEquationsSens,
+{
+    type Rhs = &'a SensRhs<Eqn>;
+    type Mass = <Eqn as OdeEquationsRef<'a>>::Mass;
+    type Root = <Eqn as OdeEquationsRef<'a>>::Root;
+    type Init = &'a SensInit<Eqn>;
+    type Out = <Eqn as OdeEquationsRef<'a>>::Out;
+}
+
 impl<Eqn> OdeEquations for SensEquations<Eqn>
 where
     Eqn: OdeEquationsSens,
 {
-    type T = Eqn::T;
-    type V = Eqn::V;
-    type M = Eqn::M;
-    type Rhs = SensRhs<Eqn>;
-    type Mass = Eqn::Mass;
-    type Root = Eqn::Root;
-    type Init = SensInit<Eqn>;
-    type Out = Eqn::Out;
-
-    fn rhs(&self) -> &Rc<Self::Rhs> {
+    fn rhs(&self) -> &SensRhs<Eqn> {
         &self.rhs
     }
-    fn mass(&self) -> Option<&Rc<Self::Mass>> {
+    fn mass(&self) -> Option<<Eqn as OdeEquationsRef<'_>>::Mass> {
         self.eqn.mass()
     }
-    fn root(&self) -> Option<&Rc<Self::Root>> {
+    fn root(&self) -> Option<<Eqn as OdeEquationsRef<'_>>::Root> {
         None
     }
-    fn init(&self) -> &Rc<Self::Init> {
+    fn init(&self) -> &SensInit<Eqn> {
         &self.init
     }
-    fn set_params(&mut self, _p: Self::V) {
-        panic!("Not implemented for SensEquations");
-    }
-    fn out(&self) -> Option<&Rc<Self::Out>> {
+    fn out(&self) -> Option<<Eqn as OdeEquationsRef<'_>>::Out> {
         None
     }
 }

--- a/src/ode_solver/sundials.rs
+++ b/src/ode_solver/sundials.rs
@@ -19,9 +19,9 @@ use std::{
 };
 
 use crate::{
-    error::*, ode_solver_error, scale, LinearOp, Matrix,
-    NonLinearOp, NonLinearOpJacobian, OdeEquationsImplicit, OdeSolverMethod, OdeSolverProblem,
-    OdeSolverState, OdeSolverStopReason, Op, SundialsMatrix, SundialsVector, Vector,
+    error::*, ode_solver_error, scale, LinearOp, Matrix, NonLinearOp, NonLinearOpJacobian,
+    OdeEquationsImplicit, OdeSolverMethod, OdeSolverProblem, OdeSolverState, OdeSolverStopReason,
+    Op, SundialsMatrix, SundialsVector, Vector,
 };
 
 #[cfg(not(sundials_version_major = "5"))]
@@ -465,10 +465,8 @@ mod test {
     use crate::{
         ode_solver::{
             test_models::{
-                exponential_decay::exponential_decay_problem,
-                foodweb::foodweb_problem,
-                heat2d::head2d_problem,
-                robertson::robertson,
+                exponential_decay::exponential_decay_problem, foodweb::foodweb_problem,
+                heat2d::head2d_problem, robertson::robertson,
             },
             tests::{
                 test_interpolate, test_no_set_problem, test_ode_solver_no_sens, test_state_mut,

--- a/src/ode_solver/sundials.rs
+++ b/src/ode_solver/sundials.rs
@@ -115,17 +115,16 @@ where
 {
     fn new(eqn: Rc<Eqn>) -> Self {
         let n = eqn.rhs().nstates();
-        let rhs = eqn.rhs();
-        let rhs_jac_sparsity = rhs.sparsity().map(|s| MatrixSparsityRef::to_owned(&s));
+        let rhs_jac_sparsity = eqn.rhs().jacobian_sparsity();
         let rhs_jac = SundialsMatrix::new_from_sparsity(n, n, rhs_jac_sparsity);
         let mass = if let Some(mass) = eqn.mass() {
-            let mass_sparsity = mass.sparsity().map(|s| MatrixSparsityRef::to_owned(&s));
+            let mass_sparsity = mass.sparsity();
             SundialsMatrix::new_from_sparsity(n, n, mass_sparsity)
         } else {
             let ones = SundialsVector::from_element(n, 1.0);
             SundialsMatrix::from_diagonal(&ones)
         };
-        Self { eqn, rhs_jac, mass }
+        Self { rhs_jac, mass, eqn }
     }
 }
 

--- a/src/ode_solver/sundials.rs
+++ b/src/ode_solver/sundials.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use crate::{
-    error::*, matrix::sparsity::MatrixSparsityRef, ode_solver_error, scale, LinearOp, Matrix,
+    error::*, ode_solver_error, scale, LinearOp, Matrix,
     NonLinearOp, NonLinearOpJacobian, OdeEquationsImplicit, OdeSolverMethod, OdeSolverProblem,
     OdeSolverState, OdeSolverStopReason, Op, SundialsMatrix, SundialsVector, Vector,
 };
@@ -466,7 +466,7 @@ mod test {
         ode_solver::{
             test_models::{
                 exponential_decay::exponential_decay_problem,
-                foodweb::{foodweb_problem, FoodWebContext},
+                foodweb::foodweb_problem,
                 heat2d::head2d_problem,
                 robertson::robertson,
             },
@@ -537,9 +537,8 @@ mod test {
 
     #[test]
     fn test_sundials_foodweb() {
-        let foodweb_context = FoodWebContext::default();
         let mut s = crate::SundialsIda::default();
-        let (problem, soln) = foodweb_problem::<crate::SundialsMatrix, 10>(&foodweb_context);
+        let (problem, soln) = foodweb_problem::<crate::SundialsMatrix, 10>();
         test_ode_solver_no_sens(&mut s, &problem, soln, None, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
         ---

--- a/src/ode_solver/test_models/exponential_decay.rs
+++ b/src/ode_solver/test_models/exponential_decay.rs
@@ -281,16 +281,16 @@ pub fn exponential_decay_problem_adjoint<M: Matrix>() -> (
     let root: Option<UnitCallable<M>> = None;
     let eqn = OdeSolverEquations::new(rhs, mass, root, init, out, p.clone());
     let rtol = M::T::from(1e-6);
-    let atol = M::V::from_element(nstates, M::T::from(1e-6));
+    let atol = Rc::new(M::V::from_element(nstates, M::T::from(1e-6)));
     let out_rtol = Some(M::T::from(1e-6));
-    let out_atol = Some(M::V::from_element(nout, M::T::from(1e-6)));
+    let out_atol = Some(Rc::new(M::V::from_element(nout, M::T::from(1e-6))));
     let param_rtol = Some(M::T::from(1e-6));
-    let param_atol = Some(M::V::from_element(p.len(), M::T::from(1e-6)));
+    let param_atol = Some(Rc::new(M::V::from_element(p.len(), M::T::from(1e-6))));
     let sens_rtol = Some(M::T::from(1e-6));
-    let sens_atol = Some(M::V::from_element(nstates, M::T::from(1e-6)));
+    let sens_atol = Some(Rc::new(M::V::from_element(nstates, M::T::from(1e-6))));
     let integrate_out = true;
     let problem = OdeSolverProblem::new(
-        eqn,
+        Rc::new(eqn),
         rtol,
         atol,
         sens_rtol,

--- a/src/ode_solver/test_models/exponential_decay.rs
+++ b/src/ode_solver/test_models/exponential_decay.rs
@@ -276,11 +276,9 @@ pub fn exponential_decay_problem_adjoint<M: Matrix>() -> (
         rhs.calculate_jacobian_sparsity(&y0, t0);
         rhs.calculate_adjoint_sparsity(&y0, t0);
     }
-    let rhs = Rc::new(rhs);
-    let init = Rc::new(init);
-    let out = Some(Rc::new(out));
-    let mass: Option<Rc<UnitCallable<M>>> = None;
-    let root: Option<Rc<UnitCallable<M>>> = None;
+    let out = Some(out);
+    let mass: Option<UnitCallable<M>> = None;
+    let root: Option<UnitCallable<M>> = None;
     let eqn = OdeSolverEquations::new(rhs, mass, root, init, out, p.clone());
     let rtol = M::T::from(1e-6);
     let atol = M::V::from_element(nstates, M::T::from(1e-6));

--- a/src/ode_solver/test_models/exponential_decay_with_algebraic.rs
+++ b/src/ode_solver/test_models/exponential_decay_with_algebraic.rs
@@ -368,14 +368,7 @@ pub fn exponential_decay_with_algebraic_problem_sens<M: Matrix + 'static>() -> (
 
     let out: Option<UnitCallable<M>> = None;
     let root: Option<UnitCallable<M>> = None;
-    let eqn = OdeSolverEquations::new(
-        rhs,
-        Some(mass),
-        root,
-        init,
-        out,
-        p.clone(),
-    );
+    let eqn = OdeSolverEquations::new(rhs, Some(mass), root, init, out, p.clone());
     let sens_rtol = Some(M::T::from(1e-6));
     let sens_atol = Some(Rc::new(M::V::from_element(3, M::T::from(1e-6))));
     let problem = OdeSolverProblem::new(

--- a/src/ode_solver/test_models/exponential_decay_with_algebraic.rs
+++ b/src/ode_solver/test_models/exponential_decay_with_algebraic.rs
@@ -286,24 +286,22 @@ pub fn exponential_decay_with_algebraic_adjoint_problem<M: Matrix + 'static>() -
         mass.calculate_sparsity(t0);
         mass.calculate_adjoint_sparsity(t0);
     }
-    let rhs = Rc::new(rhs);
-    let init = Rc::new(init);
-    let out = Some(Rc::new(out));
+    let out = Some(out);
 
-    let root: Option<Rc<UnitCallable<M>>> = None;
-    let mass = Some(Rc::new(mass));
+    let root: Option<UnitCallable<M>> = None;
+    let mass = Some(mass);
     let eqn = OdeSolverEquations::new(rhs, mass, root, init, out, p.clone());
     let rtol = M::T::from(1e-6);
-    let atol = M::V::from_element(nstates, M::T::from(1e-6));
+    let atol = Rc::new(M::V::from_element(nstates, M::T::from(1e-6)));
     let out_rtol = Some(M::T::from(1e-6));
-    let out_atol = Some(M::V::from_element(nout, M::T::from(1e-6)));
+    let out_atol = Some(Rc::new(M::V::from_element(nout, M::T::from(1e-6))));
     let param_rtol = Some(M::T::from(1e-6));
-    let param_atol = Some(M::V::from_element(1, M::T::from(1e-6)));
-    let sens_atol = Some(M::V::from_element(nstates, M::T::from(1e-6)));
+    let param_atol = Some(Rc::new(M::V::from_element(1, M::T::from(1e-6))));
+    let sens_atol = Some(Rc::new(M::V::from_element(nstates, M::T::from(1e-6))));
     let sens_rtol = Some(M::T::from(1e-6));
     let integrate_out = true;
     let problem = OdeSolverProblem::new(
-        eqn,
+        Rc::new(eqn),
         rtol,
         atol,
         sens_rtol,
@@ -368,22 +366,22 @@ pub fn exponential_decay_with_algebraic_problem_sens<M: Matrix + 'static>() -> (
         mass.calculate_sparsity(t0);
     }
 
-    let out: Option<Rc<UnitCallable<M>>> = None;
-    let root: Option<Rc<UnitCallable<M>>> = None;
+    let out: Option<UnitCallable<M>> = None;
+    let root: Option<UnitCallable<M>> = None;
     let eqn = OdeSolverEquations::new(
-        Rc::new(rhs),
-        Some(Rc::new(mass)),
+        rhs,
+        Some(mass),
         root,
-        Rc::new(init),
+        init,
         out,
         p.clone(),
     );
     let sens_rtol = Some(M::T::from(1e-6));
-    let sens_atol = Some(M::V::from_element(3, M::T::from(1e-6)));
+    let sens_atol = Some(Rc::new(M::V::from_element(3, M::T::from(1e-6))));
     let problem = OdeSolverProblem::new(
-        eqn,
+        Rc::new(eqn),
         M::T::from(1e-6),
-        M::V::from_element(3, M::T::from(1e-6)),
+        Rc::new(M::V::from_element(3, M::T::from(1e-6))),
         sens_rtol,
         sens_atol,
         None,

--- a/src/ode_solver/test_models/foodweb.rs
+++ b/src/ode_solver/test_models/foodweb.rs
@@ -420,9 +420,6 @@ where
     fn nstates(&self) -> usize {
         self.context.nstates
     }
-    fn sparsity(&self) -> Option<M::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
 }
 
 impl<M, const NX: usize> NonLinearOp for FoodWebRhs<'_, M, NX>
@@ -605,6 +602,9 @@ where
             self._default_jacobian_inplace(x, t, y);
         }
     }
+    fn jacobian_sparsity(&self) -> Option<M::Sparsity> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
+    }
 }
 
 struct FoodWebMass<'a, M, const NX: usize>
@@ -652,9 +652,7 @@ where
     fn nstates(&self) -> usize {
         self.context.nstates
     }
-    fn sparsity(&self) -> Option<M::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
 }
 
 impl<M, const NX: usize> LinearOp for FoodWebMass<'_, M, NX>
@@ -679,6 +677,9 @@ where
                 }
             }
         }
+    }
+    fn sparsity(&self) -> Option<M::SparsityRef<'_>> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
     }
 }
 
@@ -855,9 +856,7 @@ where
     fn nstates(&self) -> usize {
         NX * NX
     }
-    fn sparsity(&self) -> Option<M::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
 }
 
 #[cfg(feature = "diffsl")]
@@ -943,6 +942,9 @@ where
                 y[loc] = coy * (dcyui - dcyli) + cox * (dcxui - dcxli);
             }
         }
+    }
+    fn jacobian_sparsity(&self) -> Option<M::Sparsity> {
+        self.sparsity.as_ref().map(|&s| s.clone())
     }
 }
 

--- a/src/ode_solver/test_models/foodweb.rs
+++ b/src/ode_solver/test_models/foodweb.rs
@@ -24,6 +24,7 @@ const ALPHA: f64 = 50.0;
 const BETA: f64 = 1000.0;
 
 #[cfg(feature = "diffsl")]
+#[allow(clippy::type_complexity)]
 pub fn foodweb_diffsl_problem<M, CG, const NX: usize>() -> (
     OdeSolverProblem<impl OdeEquationsImplicit<M = M, V = M::V, T = M::T>>,
     OdeSolverSolution<M::V>,

--- a/src/ode_solver/test_models/foodweb.rs
+++ b/src/ode_solver/test_models/foodweb.rs
@@ -141,7 +141,7 @@ where
     let problem = OdeBuilder::new()
         .rtol(1e-5)
         .atol([1e-5])
-        .build_from_eqn(Rc::new(eqn))
+        .build_from_eqn(eqn)
         .unwrap();
     let soln = soln::<M>();
     (problem, soln)

--- a/src/ode_solver/test_models/heat2d.rs
+++ b/src/ode_solver/test_models/heat2d.rs
@@ -17,6 +17,7 @@ use num_traits::{One, Zero};
 use crate::{ConstantOp, LinearOp, NonLinearOpJacobian, OdeEquations};
 
 #[cfg(feature = "diffsl")]
+#[allow(clippy::type_complexity)]
 pub fn heat2d_diffsl_problem<
     M: Matrix<T = f64>,
     CG: diffsl::execution::module::CodegenModule,

--- a/src/ode_solver/test_models/heat2d.rs
+++ b/src/ode_solver/test_models/heat2d.rs
@@ -95,7 +95,7 @@ pub fn heat2d_diffsl_problem<
     let problem = OdeBuilder::new()
         .rtol(1e-7)
         .atol([1e-7])
-        .build_from_eqn(std::rc::Rc::new(eqn))
+        .build_from_eqn(eqn)
         .unwrap();
     let soln = soln::<M>();
     (problem, soln)

--- a/src/ode_solver/test_models/heat2d.rs
+++ b/src/ode_solver/test_models/heat2d.rs
@@ -24,8 +24,7 @@ pub fn heat2d_diffsl_problem<
 >() -> (
     OdeSolverProblem<impl crate::OdeEquationsImplicit<M = M, V = M::V, T = M::T>>,
     OdeSolverSolution<M::V>,
-)
-{
+) {
     use crate::{DiffSl, DiffSlContext};
 
     let (problem, _soln) = head2d_problem::<M, MGRID>();
@@ -101,7 +100,6 @@ pub fn heat2d_diffsl_problem<
     let soln = soln::<M>();
     (problem, soln)
 }
-
 
 fn heat2d_rhs<M: Matrix, const MGRID: usize>(x: &M::V, _p: &M::V, _t: M::T, y: &mut M::V) {
     // Initialize y to x, to take care of boundary equations.

--- a/src/ode_solver/test_models/robertson.rs
+++ b/src/ode_solver/test_models/robertson.rs
@@ -10,6 +10,7 @@ use crate::{
 use num_traits::Zero;
 
 #[cfg(feature = "diffsl")]
+#[allow(clippy::type_complexity)]
 pub fn robertson_diffsl_problem<
     M: Matrix<T = f64>,
     CG: diffsl::execution::module::CodegenModule,

--- a/src/ode_solver/test_models/robertson.rs
+++ b/src/ode_solver/test_models/robertson.rs
@@ -56,7 +56,7 @@ pub fn robertson_diffsl_problem<
         .p([0.04, 1.0e4, 3.0e7])
         .rtol(1e-4)
         .atol([1.0e-8, 1.0e-6, 1.0e-6])
-        .build_from_eqn(Rc::new(eqn))
+        .build_from_eqn(eqn)
         .unwrap();
     let mut soln = soln::<M::V>();
     soln.rtol = problem.rtol;

--- a/src/ode_solver/test_models/robertson.rs
+++ b/src/ode_solver/test_models/robertson.rs
@@ -16,8 +16,7 @@ pub fn robertson_diffsl_problem<
 >() -> (
     OdeSolverProblem<impl crate::OdeEquationsImplicit<M = M, V = M::V, T = M::T>>,
     OdeSolverSolution<M::V>,
-) 
-{
+) {
     use crate::{DiffSl, DiffSlContext};
 
     let code = "
@@ -189,14 +188,7 @@ pub fn robertson_sens<M: Matrix + 'static>() -> (
 
     let out: Option<UnitCallable<M>> = None;
     let root: Option<UnitCallable<M>> = None;
-    let eqn = OdeSolverEquations::new(
-        rhs,
-        Some(mass),
-        root,
-        init,
-        out,
-        p.clone(),
-    );
+    let eqn = OdeSolverEquations::new(rhs, Some(mass), root, init, out, p.clone());
     let rtol = M::T::from(1e-4);
     let atol = M::V::from_vec(vec![M::T::from(1e-8), M::T::from(1e-6), M::T::from(1e-6)]);
     let problem = OdeSolverProblem::new(

--- a/src/op/bdf.rs
+++ b/src/op/bdf.rs
@@ -1,6 +1,6 @@
 use crate::{
     matrix::DenseMatrix, ode_solver::equations::OdeEquationsImplicit, scale, LinearOp, Matrix,
-    MatrixRef, MatrixSparsity, MatrixSparsityRef, NonLinearOp, NonLinearOpJacobian,
+    MatrixRef, MatrixSparsity, NonLinearOp, NonLinearOpJacobian,
     OdeSolverProblem, Op, Vector, VectorRef,
 };
 use num_traits::{One, Zero};
@@ -88,20 +88,21 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
             n,
             rhs_jac_sparsity.map(|s| s.to_owned()),
         ));
-        let sparsity = if let Some(rhs_jac_sparsity) = eqn.rhs().sparsity() {
+        let sparsity = if let Some(rhs_jac_sparsity) = eqn.rhs().jacobian_sparsity() {
             if let Some(mass) = eqn.mass() {
-                // have mass, use the union of the mass and rhs jacobians sparse patterns
-                Some(
-                    mass.sparsity()
-                        .unwrap()
-                        .to_owned()
-                        .union(rhs_jac_sparsity)
-                        .unwrap(),
-                )
+                if let Some(mass_sparsity) = mass.sparsity() {
+                    // have mass, use the union of the mass and rhs jacobians sparse patterns
+                    Some(
+                        mass_sparsity.union(rhs_jac_sparsity.as_ref()).unwrap(),
+                    )
+                } else {
+                    // no mass sparsity, panic
+                    panic!("Mass matrix must have a sparsity pattern if the rhs jacobian has a sparsity pattern");
+                }
             } else {
                 // no mass, use the identity
                 let mass_sparsity = <Eqn::M as Matrix>::Sparsity::new_diagonal(n);
-                Some(mass_sparsity.union(rhs_jac_sparsity).unwrap())
+                Some(mass_sparsity.union(rhs_jac_sparsity.as_ref()).unwrap())
             }
         } else {
             None
@@ -274,8 +275,8 @@ where
         let number_of_jac_evals = *self.number_of_jac_evals.borrow() + 1;
         self.number_of_jac_evals.replace(number_of_jac_evals);
     }
-    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.clone()
     }
 }
 

--- a/src/op/bdf.rs
+++ b/src/op/bdf.rs
@@ -1,7 +1,7 @@
 use crate::{
     matrix::DenseMatrix, ode_solver::equations::OdeEquationsImplicit, scale, LinearOp, Matrix,
-    MatrixRef, MatrixSparsity, NonLinearOp, NonLinearOpJacobian,
-    OdeSolverProblem, Op, Vector, VectorRef,
+    MatrixRef, MatrixSparsity, NonLinearOp, NonLinearOpJacobian, OdeSolverProblem, Op, Vector,
+    VectorRef,
 };
 use num_traits::{One, Zero};
 use std::ops::MulAssign;
@@ -92,9 +92,7 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
             if let Some(mass) = eqn.mass() {
                 if let Some(mass_sparsity) = mass.sparsity() {
                     // have mass, use the union of the mass and rhs jacobians sparse patterns
-                    Some(
-                        mass_sparsity.union(rhs_jac_sparsity.as_ref()).unwrap(),
-                    )
+                    Some(mass_sparsity.union(rhs_jac_sparsity.as_ref()).unwrap())
                 } else {
                     // no mass sparsity, panic
                     panic!("Mass matrix must have a sparsity pattern if the rhs jacobian has a sparsity pattern");
@@ -201,7 +199,6 @@ impl<Eqn: OdeEquationsImplicit> Op for BdfCallable<Eqn> {
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    
 }
 
 // dF(y)/dp = dM/dp (y - y0 + psi) + Ms - c * df(y)/dp - c df(y)/dy s = 0

--- a/src/op/bdf.rs
+++ b/src/op/bdf.rs
@@ -82,7 +82,7 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
         let tmp = RefCell::new(<Eqn::V as Vector>::zeros(n));
 
         // create the mass and rhs jacobians according to the sparsity pattern
-        let rhs_jac_sparsity = eqn.rhs().sparsity();
+        let rhs_jac_sparsity = eqn.rhs().jacobian_sparsity();
         let rhs_jac = RefCell::new(Eqn::M::new_from_sparsity(
             n,
             n,
@@ -200,9 +200,7 @@ impl<Eqn: OdeEquationsImplicit> Op for BdfCallable<Eqn> {
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
 }
 
 // dF(y)/dp = dM/dp (y - y0 + psi) + Ms - c * df(y)/dp - c df(y)/dy s = 0
@@ -275,6 +273,9 @@ where
         }
         let number_of_jac_evals = *self.number_of_jac_evals.borrow() + 1;
         self.number_of_jac_evals.replace(number_of_jac_evals);
+    }
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
     }
 }
 

--- a/src/op/closure.rs
+++ b/src/op/closure.rs
@@ -51,7 +51,10 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
+        self.coloring = Some(JacobianColoring::new(
+            self.sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
 }
 
@@ -77,12 +80,11 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    
+
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
 }
-
 
 impl<M, F, G> NonLinearOp for Closure<M, F, G>
 where

--- a/src/op/closure.rs
+++ b/src/op/closure.rs
@@ -51,7 +51,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring = Some(JacobianColoring::new_from_sparsity(self.sparsity.as_ref().unwrap()));
     }
 }
 
@@ -77,13 +77,12 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
 }
+
 
 impl<M, F, G> NonLinearOp for Closure<M, F, G>
 where
@@ -114,5 +113,8 @@ where
         } else {
             self._default_jacobian_inplace(x, t, y);
         }
+    }
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.clone()
     }
 }

--- a/src/op/closure.rs
+++ b/src/op/closure.rs
@@ -51,7 +51,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new_from_sparsity(self.sparsity.as_ref().unwrap()));
+        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
     }
 }
 

--- a/src/op/closure_with_adjoint.rs
+++ b/src/op/closure_with_adjoint.rs
@@ -125,15 +125,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
-    fn sparsity_adjoint(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity_adjoint.as_ref().map(|s| s.as_ref())
-    }
-    fn sparsity_sens_adjoint(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sens_sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -173,6 +165,10 @@ where
             self._default_jacobian_inplace(x, t, y);
         }
     }
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
+    }
+    
 }
 
 impl<M, F, G, H, I> NonLinearOpAdjoint for ClosureWithAdjoint<M, F, G, H, I>
@@ -195,6 +191,10 @@ where
             self._default_adjoint_inplace(x, t, y);
         }
     }
+    fn adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity_adjoint.as_ref().map(|s| s.clone())
+    }
+    
 }
 
 impl<M, F, G, H, I> NonLinearOpSensAdjoint for ClosureWithAdjoint<M, F, G, H, I>
@@ -214,5 +214,8 @@ where
         } else {
             self._default_sens_adjoint_inplace(x, t, y);
         }
+    }
+    fn sens_adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sens_sparsity.as_ref().map(|s| s.as_ref())
     }
 }

--- a/src/op/closure_with_adjoint.rs
+++ b/src/op/closure_with_adjoint.rs
@@ -79,7 +79,10 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
+        self.coloring = Some(JacobianColoring::new(
+            self.sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
 
     pub fn calculate_adjoint_sparsity(&mut self, y0: &M::V, t0: M::T) {
@@ -88,7 +91,10 @@ where
             MatrixSparsity::try_from_indices(self.nstates, self.nout, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring_adjoint = Some(JacobianColoring::new(self.sparsity_adjoint.as_ref().unwrap(), &non_zeros));
+        self.coloring_adjoint = Some(JacobianColoring::new(
+            self.sparsity_adjoint.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
 
     pub fn calculate_sens_adjoint_sparsity(&mut self, y0: &M::V, t0: M::T) {
@@ -97,7 +103,10 @@ where
             MatrixSparsity::try_from_indices(self.nstates, self.nparams, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring_sens_adjoint = Some(JacobianColoring::new(self.sens_sparsity.as_ref().unwrap(), &non_zeros));
+        self.coloring_sens_adjoint = Some(JacobianColoring::new(
+            self.sens_sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
 }
 
@@ -125,7 +134,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    
+
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -168,7 +177,6 @@ where
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.sparsity.clone()
     }
-    
 }
 
 impl<M, F, G, H, I> NonLinearOpAdjoint for ClosureWithAdjoint<M, F, G, H, I>
@@ -194,7 +202,6 @@ where
     fn adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.sparsity_adjoint.clone()
     }
-    
 }
 
 impl<M, F, G, H, I> NonLinearOpSensAdjoint for ClosureWithAdjoint<M, F, G, H, I>

--- a/src/op/closure_with_adjoint.rs
+++ b/src/op/closure_with_adjoint.rs
@@ -79,7 +79,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
     }
 
     pub fn calculate_adjoint_sparsity(&mut self, y0: &M::V, t0: M::T) {
@@ -88,7 +88,7 @@ where
             MatrixSparsity::try_from_indices(self.nstates, self.nout, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring_adjoint = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring_adjoint = Some(JacobianColoring::new(self.sparsity_adjoint.as_ref().unwrap(), &non_zeros));
     }
 
     pub fn calculate_sens_adjoint_sparsity(&mut self, y0: &M::V, t0: M::T) {
@@ -97,7 +97,7 @@ where
             MatrixSparsity::try_from_indices(self.nstates, self.nparams, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring_sens_adjoint = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring_sens_adjoint = Some(JacobianColoring::new(self.sens_sparsity.as_ref().unwrap(), &non_zeros));
     }
 }
 
@@ -165,8 +165,8 @@ where
             self._default_jacobian_inplace(x, t, y);
         }
     }
-    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.clone()
     }
     
 }
@@ -192,7 +192,7 @@ where
         }
     }
     fn adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.sparsity_adjoint.as_ref().map(|s| s.clone())
+        self.sparsity_adjoint.clone()
     }
     
 }
@@ -216,6 +216,6 @@ where
         }
     }
     fn sens_adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.sens_sparsity.as_ref().map(|s| s.as_ref())
+        self.sens_sparsity.clone()
     }
 }

--- a/src/op/closure_with_sens.rs
+++ b/src/op/closure_with_sens.rs
@@ -66,7 +66,10 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
+        self.coloring = Some(JacobianColoring::new(
+            self.sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
     pub fn calculate_sens_sparsity(&mut self, y0: &M::V, t0: M::T) {
         let non_zeros = find_sens_non_zeros(self, y0, t0);
@@ -74,7 +77,10 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nparams, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.sens_coloring = Some(JacobianColoring::new(self.sens_sparsity.as_ref().unwrap(), &non_zeros));
+        self.sens_coloring = Some(JacobianColoring::new(
+            self.sens_sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
 }
 
@@ -101,7 +107,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    
+
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -142,7 +148,6 @@ where
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.sparsity.clone()
     }
-    
 }
 
 impl<M, F, G, H> NonLinearOpSens for ClosureWithSens<M, F, G, H>

--- a/src/op/closure_with_sens.rs
+++ b/src/op/closure_with_sens.rs
@@ -101,12 +101,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|x| x.as_ref())
-    }
-    fn sparsity_sens(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sens_sparsity.as_ref().map(|x| x.as_ref())
-    }
+    
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -144,6 +139,10 @@ where
             self._default_jacobian_inplace(x, t, y);
         }
     }
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.as_ref().map(|x| x.as_ref())
+    }
+    
 }
 
 impl<M, F, G, H> NonLinearOpSens for ClosureWithSens<M, F, G, H>
@@ -163,5 +162,8 @@ where
         } else {
             self._default_sens_inplace(x, t, y);
         }
+    }
+    fn sens_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sens_sparsity.as_ref().map(|x| x.as_ref())
     }
 }

--- a/src/op/closure_with_sens.rs
+++ b/src/op/closure_with_sens.rs
@@ -66,7 +66,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
     }
     pub fn calculate_sens_sparsity(&mut self, y0: &M::V, t0: M::T) {
         let non_zeros = find_sens_non_zeros(self, y0, t0);
@@ -74,7 +74,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nparams, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.sens_coloring = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.sens_coloring = Some(JacobianColoring::new(self.sens_sparsity.as_ref().unwrap(), &non_zeros));
     }
 }
 
@@ -140,7 +140,7 @@ where
         }
     }
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.sparsity.as_ref().map(|x| x.as_ref())
+        self.sparsity.clone()
     }
     
 }
@@ -164,6 +164,6 @@ where
         }
     }
     fn sens_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.sens_sparsity.as_ref().map(|x| x.as_ref())
+        self.sens_sparsity.clone()
     }
 }

--- a/src/op/constant_closure_with_adjoint.rs
+++ b/src/op/constant_closure_with_adjoint.rs
@@ -83,7 +83,7 @@ where
     I: Fn(&M::V, M::T) -> M::V,
     J: Fn(&M::V, M::T, &M::V, &mut M::V),
 {
-    fn sens_mul_transpose_inplace(&self, t: Self::T, v: &Self::V, y: &mut Self::V) {
+    fn sens_transpose_mul_inplace(&self, t: Self::T, v: &Self::V, y: &mut Self::V) {
         (self.func_sens_adjoint)(self.p.as_ref(), t, v, y);
     }
 }

--- a/src/op/constant_op.rs
+++ b/src/op/constant_op.rs
@@ -1,5 +1,5 @@
 use super::Op;
-use crate::{Matrix, MatrixSparsityRef, Vector};
+use crate::{Matrix, Vector};
 use num_traits::{One, Zero};
 
 pub trait ConstantOp: Op {
@@ -41,14 +41,51 @@ pub trait ConstantOpSens: ConstantOp {
     fn sens(&self, t: Self::T) -> Self::M {
         let n = self.nstates();
         let m = self.nparams();
-        let mut y = Self::M::new_from_sparsity(n, m, self.sparsity_sens().map(|s| s.to_owned()));
+        let mut y = Self::M::new_from_sparsity(n, m, self.sens_sparsity());
         self.sens_inplace(t, &mut y);
         y
+    }
+    fn sens_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
     }
 }
 
 pub trait ConstantOpSensAdjoint: ConstantOp {
     /// Compute the product of the transpose of the gradient of F wrt a parameter vector p with a given vector `-J_p^T(x, t) * v`.
     /// Note that the vector v is of size nstates() and the result is of size nparam().
-    fn sens_mul_transpose_inplace(&self, _t: Self::T, _v: &Self::V, _y: &mut Self::V);
+    fn sens_transpose_mul_inplace(&self, _t: Self::T, _v: &Self::V, _y: &mut Self::V);
+
+    /// Compute the negative transpose of the gradient of the operator wrt a parameter vector p and return it.
+    /// See [Self::sens_adjoint_inplace] for a non-allocating version.
+    fn sens_adjoint(&self, t: Self::T) -> Self::M {
+        let n = self.nstates();
+        let mut y =
+            Self::M::new_from_sparsity(n, n, self.sens_adjoint_sparsity());
+        self.sens_adjoint_inplace(t, &mut y);
+        y
+    }
+
+    /// Compute the negative transpose of the gradient of the operator wrt a parameter vector p and store it in the matrix `y`.
+    /// `y` should have been previously initialised using the output of [`Op::sparsity_sens_adjoint`].
+    /// The default implementation of this method computes the gradient using [Self::sens_transpose_mul_inplace],
+    /// but it can be overriden for more efficient implementations.
+    fn sens_adjoint_inplace(&self, t: Self::T, y: &mut Self::M) {
+        self._default_sens_adjoint_inplace(t, y);
+    }
+
+    /// Default implementation of the gradient computation (this is the default for [Self::sens_adjoint_inplace]).
+    fn _default_sens_adjoint_inplace(&self, t: Self::T, y: &mut Self::M) {
+        let mut v = Self::V::zeros(self.nstates());
+        let mut col = Self::V::zeros(self.nout());
+        for j in 0..self.nstates() {
+            v[j] = Self::T::one();
+            self.sens_transpose_mul_inplace(t, &v, &mut col);
+            y.set_column(j, &col);
+            v[j] = Self::T::zero();
+        }
+    }
+    
+    fn sens_adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
+    }
 }

--- a/src/op/constant_op.rs
+++ b/src/op/constant_op.rs
@@ -17,7 +17,7 @@ pub trait ConstantOpSens: ConstantOp {
     fn sens_mul_inplace(&self, _t: Self::T, _v: &Self::V, _y: &mut Self::V);
 
     /// Compute the gradient of the operator wrt a parameter vector p and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity`].
+    /// `y` should have been previously initialised using the output of [Self::sens_sparsity].
     /// The default implementation of this method computes the gradient using [Self::sens_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn sens_inplace(&self, t: Self::T, y: &mut Self::M) {
@@ -65,7 +65,7 @@ pub trait ConstantOpSensAdjoint: ConstantOp {
     }
 
     /// Compute the negative transpose of the gradient of the operator wrt a parameter vector p and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity_sens_adjoint`].
+    /// `y` should have been previously initialised using the output of [Self::sens_adjoint_sparsity].
     /// The default implementation of this method computes the gradient using [Self::sens_transpose_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn sens_adjoint_inplace(&self, t: Self::T, y: &mut Self::M) {

--- a/src/op/constant_op.rs
+++ b/src/op/constant_op.rs
@@ -59,8 +59,7 @@ pub trait ConstantOpSensAdjoint: ConstantOp {
     /// See [Self::sens_adjoint_inplace] for a non-allocating version.
     fn sens_adjoint(&self, t: Self::T) -> Self::M {
         let n = self.nstates();
-        let mut y =
-            Self::M::new_from_sparsity(n, n, self.sens_adjoint_sparsity());
+        let mut y = Self::M::new_from_sparsity(n, n, self.sens_adjoint_sparsity());
         self.sens_adjoint_inplace(t, &mut y);
         y
     }
@@ -84,7 +83,7 @@ pub trait ConstantOpSensAdjoint: ConstantOp {
             v[j] = Self::T::zero();
         }
     }
-    
+
     fn sens_adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         None
     }

--- a/src/op/init.rs
+++ b/src/op/init.rs
@@ -1,5 +1,5 @@
 use crate::{
-    scale, LinearOp, Matrix, NonLinearOpJacobian, OdeEquationsImplicit, Vector, VectorIndex,
+    scale, LinearOp, Matrix, NonLinearOpJacobian, OdeEquationsImplicit, Vector, VectorIndex, MatrixSparsityRef
 };
 use num_traits::{One, Zero};
 use std::{cell::RefCell, rc::Rc};
@@ -115,7 +115,7 @@ impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for InitOp<Eqn> {
     }
     
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.jac.sparsity()
+        self.jac.sparsity().map(|x| x.to_owned())
     }
 }
 

--- a/src/op/init.rs
+++ b/src/op/init.rs
@@ -83,9 +83,7 @@ impl<Eqn: OdeEquationsImplicit> Op for InitOp<Eqn> {
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.jac.sparsity()
-    }
+    
 }
 
 impl<Eqn: OdeEquationsImplicit> NonLinearOp for InitOp<Eqn> {
@@ -114,6 +112,10 @@ impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for InitOp<Eqn> {
     // M - c * f'(y)
     fn jacobian_inplace(&self, _x: &Self::V, _t: Self::T, y: &mut Self::M) {
         y.copy_from(&self.jac);
+    }
+    
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.jac.sparsity()
     }
 }
 

--- a/src/op/init.rs
+++ b/src/op/init.rs
@@ -1,5 +1,6 @@
 use crate::{
-    scale, LinearOp, Matrix, NonLinearOpJacobian, OdeEquationsImplicit, Vector, VectorIndex, MatrixSparsityRef
+    scale, LinearOp, Matrix, MatrixSparsityRef, NonLinearOpJacobian, OdeEquationsImplicit, Vector,
+    VectorIndex,
 };
 use num_traits::{One, Zero};
 use std::{cell::RefCell, rc::Rc};
@@ -83,7 +84,6 @@ impl<Eqn: OdeEquationsImplicit> Op for InitOp<Eqn> {
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    
 }
 
 impl<Eqn: OdeEquationsImplicit> NonLinearOp for InitOp<Eqn> {
@@ -113,7 +113,7 @@ impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for InitOp<Eqn> {
     fn jacobian_inplace(&self, _x: &Self::V, _t: Self::T, y: &mut Self::M) {
         y.copy_from(&self.jac);
     }
-    
+
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.jac.sparsity().map(|x| x.to_owned())
     }

--- a/src/op/linear_closure.rs
+++ b/src/op/linear_closure.rs
@@ -47,7 +47,10 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
+        self.coloring = Some(JacobianColoring::new(
+            self.sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
 }
 
@@ -73,7 +76,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    
+
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }

--- a/src/op/linear_closure.rs
+++ b/src/op/linear_closure.rs
@@ -47,7 +47,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
     }
 }
 
@@ -98,6 +98,6 @@ where
         }
     }
     fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
+        self.sparsity.clone()
     }
 }

--- a/src/op/linear_closure.rs
+++ b/src/op/linear_closure.rs
@@ -73,9 +73,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -98,5 +96,8 @@ where
         } else {
             self._default_matrix_inplace(t, y);
         }
+    }
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
     }
 }

--- a/src/op/linear_closure_with_adjoint.rs
+++ b/src/op/linear_closure_with_adjoint.rs
@@ -55,7 +55,10 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
+        self.coloring = Some(JacobianColoring::new(
+            self.sparsity.as_ref().unwrap(),
+            &non_zeros,
+        ));
     }
     pub fn calculate_adjoint_sparsity(&mut self, t0: M::T) {
         let non_zeros = find_transpose_non_zeros(self, t0);
@@ -64,7 +67,8 @@ where
                 .expect("invalid sparsity pattern"),
         );
         self.coloring_adjoint = Some(JacobianColoring::new(
-            self.sparsity_adjoint.as_ref().unwrap(), &non_zeros,
+            self.sparsity_adjoint.as_ref().unwrap(),
+            &non_zeros,
         ));
     }
 }
@@ -92,7 +96,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    
+
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -138,7 +142,7 @@ where
             self._default_transpose_inplace(t, y);
         }
     }
-    
+
     fn transpose_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.sparsity_adjoint.clone()
     }

--- a/src/op/linear_closure_with_adjoint.rs
+++ b/src/op/linear_closure_with_adjoint.rs
@@ -90,12 +90,7 @@ where
         assert_eq!(p.len(), self.nparams);
         self.p = p;
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
-    fn sparsity_adjoint(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity_adjoint.as_ref().map(|s| s.as_ref())
-    }
+    
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()
     }
@@ -120,6 +115,9 @@ where
             self._default_matrix_inplace(t, y);
         }
     }
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
+    }
 }
 
 impl<M, F, G> LinearOpTranspose for LinearClosureWithAdjoint<M, F, G>
@@ -137,5 +135,9 @@ where
         } else {
             self._default_transpose_inplace(t, y);
         }
+    }
+    
+    fn transpose_sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
+        self.sparsity_adjoint.as_ref().map(|s| s.as_ref())
     }
 }

--- a/src/op/linear_closure_with_adjoint.rs
+++ b/src/op/linear_closure_with_adjoint.rs
@@ -55,7 +55,7 @@ where
             MatrixSparsity::try_from_indices(self.nout(), self.nstates(), non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring = Some(JacobianColoring::new(self.sparsity.as_ref().unwrap(), &non_zeros));
     }
     pub fn calculate_adjoint_sparsity(&mut self, t0: M::T) {
         let non_zeros = find_transpose_non_zeros(self, t0);
@@ -63,7 +63,9 @@ where
             MatrixSparsity::try_from_indices(self.nstates, self.nout, non_zeros.clone())
                 .expect("invalid sparsity pattern"),
         );
-        self.coloring_adjoint = Some(JacobianColoring::new_from_non_zeros(self, non_zeros));
+        self.coloring_adjoint = Some(JacobianColoring::new(
+            self.sparsity_adjoint.as_ref().unwrap(), &non_zeros,
+        ));
     }
 }
 
@@ -115,8 +117,8 @@ where
             self._default_matrix_inplace(t, y);
         }
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.clone()
     }
 }
 
@@ -137,7 +139,7 @@ where
         }
     }
     
-    fn transpose_sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity_adjoint.as_ref().map(|s| s.as_ref())
+    fn transpose_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity_adjoint.clone()
     }
 }

--- a/src/op/linear_op.rs
+++ b/src/op/linear_op.rs
@@ -96,7 +96,7 @@ pub trait LinearOpSens: LinearOp {
     }
 
     /// Compute the gradient of the operator wrt a parameter vector p and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity`].
+    /// `y` should have been previously initialised using the output of [Self::sens_sparsity].
     /// The default implementation of this method computes the gradient using [Self::sens_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn sens_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::M) {

--- a/src/op/linear_op.rs
+++ b/src/op/linear_op.rs
@@ -19,11 +19,7 @@ pub trait LinearOp: Op {
     /// Compute the matrix representation of the operator `A(t)` and return it.
     /// See [Self::matrix_inplace] for a non-allocating version.
     fn matrix(&self, t: Self::T) -> Self::M {
-        let mut y = Self::M::new_from_sparsity(
-            self.nstates(),
-            self.nstates(),
-            self.sparsity(),
-        );
+        let mut y = Self::M::new_from_sparsity(self.nstates(), self.nstates(), self.sparsity());
         self.matrix_inplace(t, &mut y);
         y
     }
@@ -46,7 +42,7 @@ pub trait LinearOp: Op {
             v[j] = Self::T::zero();
         }
     }
-    
+
     fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         None
     }

--- a/src/op/linear_op.rs
+++ b/src/op/linear_op.rs
@@ -46,6 +46,10 @@ pub trait LinearOp: Op {
             v[j] = Self::T::zero();
         }
     }
+    
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
+    }
 }
 
 pub trait LinearOpTranspose: LinearOp {
@@ -75,6 +79,9 @@ pub trait LinearOpTranspose: LinearOp {
             y.set_column(j, &col);
             v[j] = Self::T::zero();
         }
+    }
+    fn transpose_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
     }
 }
 

--- a/src/op/linear_op.rs
+++ b/src/op/linear_op.rs
@@ -1,5 +1,5 @@
 use super::Op;
-use crate::{Matrix, MatrixSparsityRef, Vector};
+use crate::{Matrix, Vector};
 use num_traits::{One, Zero};
 
 /// LinearOp is a trait for linear operators (i.e. they only depend linearly on the input `x`), see [crate::NonLinearOp] for a non-linear op.
@@ -22,7 +22,7 @@ pub trait LinearOp: Op {
         let mut y = Self::M::new_from_sparsity(
             self.nstates(),
             self.nstates(),
-            self.sparsity().map(|s| s.to_owned()),
+            self.sparsity(),
         );
         self.matrix_inplace(t, &mut y);
         y
@@ -124,8 +124,12 @@ pub trait LinearOpSens: LinearOp {
     fn sens(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
         let m = self.nparams();
-        let mut y = Self::M::new_from_sparsity(n, m, self.sparsity_sens().map(|s| s.to_owned()));
+        let mut y = Self::M::new_from_sparsity(n, m, self.sens_sparsity());
         self.sens_inplace(x, t, &mut y);
         y
+    }
+
+    fn sens_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
     }
 }

--- a/src/op/linearise.rs
+++ b/src/op/linearise.rs
@@ -51,9 +51,7 @@ impl<C: NonLinearOpJacobian> Op for LinearisedOp<C> {
     fn nparams(&self) -> usize {
         self.callable.nparams()
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.callable.sparsity()
-    }
+    
 }
 
 impl<C: NonLinearOpJacobian> LinearOp for LinearisedOp<C> {
@@ -68,5 +66,8 @@ impl<C: NonLinearOpJacobian> LinearOp for LinearisedOp<C> {
     }
     fn matrix_inplace(&self, t: Self::T, y: &mut Self::M) {
         self.callable.jacobian_inplace(&self.x, t, y);
+    }
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.callable.sparsity()
     }
 }

--- a/src/op/linearise.rs
+++ b/src/op/linearise.rs
@@ -68,6 +68,6 @@ impl<C: NonLinearOpJacobian> LinearOp for LinearisedOp<C> {
         self.callable.jacobian_inplace(&self.x, t, y);
     }
     fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.callable.sparsity()
+        self.callable.jacobian_sparsity()
     }
 }

--- a/src/op/linearise.rs
+++ b/src/op/linearise.rs
@@ -51,7 +51,6 @@ impl<C: NonLinearOpJacobian> Op for LinearisedOp<C> {
     fn nparams(&self) -> usize {
         self.callable.nparams()
     }
-    
 }
 
 impl<C: NonLinearOpJacobian> LinearOp for LinearisedOp<C> {

--- a/src/op/matrix.rs
+++ b/src/op/matrix.rs
@@ -1,4 +1,4 @@
-use crate::{LinearOp, Matrix, Op};
+use crate::{LinearOp, Matrix, Op, MatrixSparsityRef};
 
 pub struct MatrixOp<M: Matrix> {
     m: M,
@@ -31,6 +31,6 @@ impl<M: Matrix> LinearOp for MatrixOp<M> {
         self.m.gemv(t, x, beta, y);
     }
     fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
-        self.m.sparsity()
+        self.m.sparsity().map(|s| s.to_owned())
     }
 }

--- a/src/op/matrix.rs
+++ b/src/op/matrix.rs
@@ -1,4 +1,4 @@
-use crate::{LinearOp, Matrix, Op, MatrixSparsityRef};
+use crate::{LinearOp, Matrix, MatrixSparsityRef, Op};
 
 pub struct MatrixOp<M: Matrix> {
     m: M,
@@ -23,7 +23,6 @@ impl<M: Matrix> Op for MatrixOp<M> {
     fn nparams(&self) -> usize {
         0
     }
-    
 }
 
 impl<M: Matrix> LinearOp for MatrixOp<M> {

--- a/src/op/matrix.rs
+++ b/src/op/matrix.rs
@@ -23,13 +23,14 @@ impl<M: Matrix> Op for MatrixOp<M> {
     fn nparams(&self) -> usize {
         0
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.m.sparsity()
-    }
+    
 }
 
 impl<M: Matrix> LinearOp for MatrixOp<M> {
     fn gemv_inplace(&self, x: &Self::V, t: Self::T, beta: Self::T, y: &mut Self::V) {
         self.m.gemv(t, x, beta, y);
+    }
+    fn sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.m.sparsity()
     }
 }

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -1,6 +1,9 @@
 use std::rc::Rc;
 
-use crate::{ConstantOp, ConstantOpSens, LinearOp, LinearOpTranspose, Matrix, NonLinearOp, NonLinearOpAdjoint, NonLinearOpSens, NonLinearOpSensAdjoint, Scalar, Vector, ConstantOpSensAdjoint};
+use crate::{
+    ConstantOp, ConstantOpSens, ConstantOpSensAdjoint, LinearOp, LinearOpTranspose, Matrix,
+    NonLinearOp, NonLinearOpAdjoint, NonLinearOpSens, NonLinearOpSensAdjoint, Scalar, Vector,
+};
 
 use nonlinear_op::NonLinearOpJacobian;
 use serde::Serialize;
@@ -55,7 +58,6 @@ pub trait Op {
         OpStatistics::default()
     }
 }
-
 
 #[derive(Default, Clone, Serialize)]
 pub struct OpStatistics {
@@ -164,7 +166,6 @@ impl<C: NonLinearOpSensAdjoint> NonLinearOpSensAdjoint for &C {
         C::sens_adjoint_sparsity(*self)
     }
 }
-
 
 impl<C: LinearOp> LinearOp for &C {
     fn gemv_inplace(&self, x: &Self::V, t: Self::T, beta: Self::T, y: &mut Self::V) {

--- a/src/op/nonlinear_op.rs
+++ b/src/op/nonlinear_op.rs
@@ -58,9 +58,12 @@ pub trait NonLinearOpSens: NonLinearOp {
     fn sens(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
         let m = self.nparams();
-        let mut y = Self::M::new_from_sparsity(n, m, self.sparsity_sens().map(|s| s.to_owned()));
+        let mut y = Self::M::new_from_sparsity(n, m, self.sens_sparsity().map(|s| s.to_owned()));
         self.sens_inplace(x, t, &mut y);
         y
+    }
+    fn sens_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
     }
 }
 pub trait NonLinearOpSensAdjoint: NonLinearOp {
@@ -95,6 +98,10 @@ pub trait NonLinearOpSensAdjoint: NonLinearOp {
             y.set_column(j, &col);
             v[j] = Self::T::zero();
         }
+    }
+    
+    fn sens_adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
     }
 }
 pub trait NonLinearOpAdjoint: NonLinearOp {
@@ -131,6 +138,10 @@ pub trait NonLinearOpAdjoint: NonLinearOp {
         self.adjoint_inplace(x, t, &mut y);
         y
     }
+    /// Return sparsity information (if available)
+    fn adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
+    }
 }
 pub trait NonLinearOpJacobian: NonLinearOp {
     /// Compute the product of the Jacobian with a given vector `J(x, t) * v`.
@@ -151,6 +162,11 @@ pub trait NonLinearOpJacobian: NonLinearOp {
         let mut y = Self::M::new_from_sparsity(n, n, self.sparsity().map(|s| s.to_owned()));
         self.jacobian_inplace(x, t, &mut y);
         y
+    }
+    
+    /// Return sparsity information (if available)
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        None
     }
 
     /// Compute the Jacobian matrix `J(x, t)` of the operator and store it in the matrix `y`.

--- a/src/op/nonlinear_op.rs
+++ b/src/op/nonlinear_op.rs
@@ -74,8 +74,7 @@ pub trait NonLinearOpSensAdjoint: NonLinearOp {
     /// See [Self::sens_adjoint_inplace] for a non-allocating version.
     fn sens_adjoint(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
-        let mut y =
-            Self::M::new_from_sparsity(n, n, self.sens_adjoint_sparsity());
+        let mut y = Self::M::new_from_sparsity(n, n, self.sens_adjoint_sparsity());
         self.sens_adjoint_inplace(x, t, &mut y);
         y
     }
@@ -99,7 +98,7 @@ pub trait NonLinearOpSensAdjoint: NonLinearOp {
             v[j] = Self::T::zero();
         }
     }
-    
+
     fn sens_adjoint_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         None
     }
@@ -163,7 +162,7 @@ pub trait NonLinearOpJacobian: NonLinearOp {
         self.jacobian_inplace(x, t, &mut y);
         y
     }
-    
+
     /// Return sparsity information (if available)
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         None

--- a/src/op/nonlinear_op.rs
+++ b/src/op/nonlinear_op.rs
@@ -34,7 +34,7 @@ pub trait NonLinearOpSens: NonLinearOp {
     }
 
     /// Compute the gradient of the operator wrt a parameter vector p and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity`].
+    /// `y` should have been previously initialised using the output of [Self::sens_sparsity].
     /// The default implementation of this method computes the gradient using [Self::sens_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn sens_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::M) {
@@ -80,7 +80,7 @@ pub trait NonLinearOpSensAdjoint: NonLinearOp {
     }
 
     /// Compute the negative transpose of the gradient of the operator wrt a parameter vector p and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity_sens_adjoint`].
+    /// `y` should have been previously initialised using the output of [Self::sens_adjoint_sparsity].
     /// The default implementation of this method computes the gradient using [Self::sens_transpose_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn sens_adjoint_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::M) {
@@ -110,7 +110,7 @@ pub trait NonLinearOpAdjoint: NonLinearOp {
     fn jac_transpose_mul_inplace(&self, _x: &Self::V, _t: Self::T, _v: &Self::V, _y: &mut Self::V);
 
     /// Compute the Adjoint matrix `-J^T(x, t)` of the operator and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity`].
+    /// `y` should have been previously initialised using the output of [`Self::adjoint_sparsity`].
     /// The default implementation of this method computes the Jacobian using [Self::jac_transpose_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn adjoint_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::M) {
@@ -169,7 +169,7 @@ pub trait NonLinearOpJacobian: NonLinearOp {
     }
 
     /// Compute the Jacobian matrix `J(x, t)` of the operator and store it in the matrix `y`.
-    /// `y` should have been previously initialised using the output of [`Op::sparsity`].
+    /// `y` should have been previously initialised using the output of [Self::jacobian_sparsity].
     /// The default implementation of this method computes the Jacobian using [Self::jac_mul_inplace],
     /// but it can be overriden for more efficient implementations.
     fn jacobian_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::M) {

--- a/src/op/nonlinear_op.rs
+++ b/src/op/nonlinear_op.rs
@@ -1,5 +1,5 @@
 use super::Op;
-use crate::{Matrix, MatrixSparsityRef, Vector};
+use crate::{Matrix, Vector};
 use num_traits::{One, Zero};
 
 // NonLinearOp is a trait that defines a nonlinear operator or function `F` that maps an input vector `x` to an output vector `y`, (i.e. `y = F(x, t)`).
@@ -58,7 +58,7 @@ pub trait NonLinearOpSens: NonLinearOp {
     fn sens(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
         let m = self.nparams();
-        let mut y = Self::M::new_from_sparsity(n, m, self.sens_sparsity().map(|s| s.to_owned()));
+        let mut y = Self::M::new_from_sparsity(n, m, self.sens_sparsity());
         self.sens_inplace(x, t, &mut y);
         y
     }
@@ -75,7 +75,7 @@ pub trait NonLinearOpSensAdjoint: NonLinearOp {
     fn sens_adjoint(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
         let mut y =
-            Self::M::new_from_sparsity(n, n, self.sparsity_sens_adjoint().map(|s| s.to_owned()));
+            Self::M::new_from_sparsity(n, n, self.sens_adjoint_sparsity());
         self.sens_adjoint_inplace(x, t, &mut y);
         y
     }
@@ -134,7 +134,7 @@ pub trait NonLinearOpAdjoint: NonLinearOp {
     /// See [Self::adjoint_inplace] for a non-allocating version.
     fn adjoint(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
-        let mut y = Self::M::new_from_sparsity(n, n, self.sparsity_adjoint().map(|s| s.to_owned()));
+        let mut y = Self::M::new_from_sparsity(n, n, self.adjoint_sparsity());
         self.adjoint_inplace(x, t, &mut y);
         y
     }
@@ -159,7 +159,7 @@ pub trait NonLinearOpJacobian: NonLinearOp {
     /// See [Self::jacobian_inplace] for a non-allocating version.
     fn jacobian(&self, x: &Self::V, t: Self::T) -> Self::M {
         let n = self.nstates();
-        let mut y = Self::M::new_from_sparsity(n, n, self.sparsity().map(|s| s.to_owned()));
+        let mut y = Self::M::new_from_sparsity(n, n, self.jacobian_sparsity());
         self.jacobian_inplace(x, t, &mut y);
         y
     }

--- a/src/op/sdirk.rs
+++ b/src/op/sdirk.rs
@@ -1,8 +1,8 @@
 use crate::{
     matrix::{MatrixRef, MatrixView},
     ode_solver::equations::OdeEquations,
-    scale, LinearOp, Matrix, MatrixSparsity, NonLinearOpJacobian,
-    OdeEquationsImplicit, OdeSolverProblem, Vector, VectorRef,
+    scale, LinearOp, Matrix, MatrixSparsity, NonLinearOpJacobian, OdeEquationsImplicit,
+    OdeSolverProblem, Vector, VectorRef,
 };
 use num_traits::{One, Zero};
 use std::{
@@ -81,11 +81,7 @@ impl<Eqn: OdeEquationsImplicit> SdirkCallable<Eqn> {
             if let Some(mass) = eqn.mass() {
                 if let Some(mass_sparsity) = mass.sparsity() {
                     // have mass, use the union of the mass and rhs jacobians sparse patterns
-                    Some(
-                        mass_sparsity
-                            .union(rhs_jac_sparsity.as_ref())
-                            .unwrap(),
-                    )
+                    Some(mass_sparsity.union(rhs_jac_sparsity.as_ref()).unwrap())
                 } else {
                     // no mass sparsity, panic!
                     panic!("Mass matrix must have a sparsity pattern if the rhs jacobian has a sparsity pattern")
@@ -182,7 +178,6 @@ impl<Eqn: OdeEquations> Op for SdirkCallable<Eqn> {
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    
 }
 
 impl<Eqn: OdeEquationsImplicit> NonLinearOp for SdirkCallable<Eqn>

--- a/src/op/sdirk.rs
+++ b/src/op/sdirk.rs
@@ -179,9 +179,7 @@ impl<Eqn: OdeEquations> Op for SdirkCallable<Eqn> {
     fn nparams(&self) -> usize {
         self.eqn.rhs().nparams()
     }
-    fn sparsity(&self) -> Option<<Self::M as Matrix>::SparsityRef<'_>> {
-        self.sparsity.as_ref().map(|s| s.as_ref())
-    }
+    
 }
 
 impl<Eqn: OdeEquations> NonLinearOp for SdirkCallable<Eqn>
@@ -256,6 +254,9 @@ where
         }
         let number_of_jac_evals = *self.number_of_jac_evals.borrow() + 1;
         self.number_of_jac_evals.replace(number_of_jac_evals);
+    }
+    fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
+        self.sparsity.as_ref().map(|s| s.as_ref())
     }
 }
 

--- a/src/vector/sundials.rs
+++ b/src/vector/sundials.rs
@@ -44,7 +44,7 @@ impl SundialsVector {
         #[cfg(not(sundials_version_major = "5"))]
         let nv = {
             let ctx = get_suncontext();
-            unsafe { N_VNew_Serial(len as i32, *ctx) }
+            unsafe { N_VNew_Serial(len as i64, *ctx) }
         };
 
         #[cfg(sundials_version_major = "5")]


### PR DESCRIPTION
refactor: sparsity returned as owned
refactor: sparsity functions moved from Op to relevent traits
refactor: diffsl struct owns context, now has 'static lifetime