### PR TITLE
Fix CUDA PTX path

### DIFF
--- a/diffsol/src/context/cuda.rs
+++ b/diffsol/src/context/cuda.rs
@@ -43,7 +43,7 @@ pub struct CudaContext {
 impl CudaContext {
     /// Compiles the PTX files for the given device.
     fn compile_ptx(device: &Arc<CudaDevice>) -> Result<Arc<CudaModule>, DiffsolError> {
-        let out_dir = env::var("OUT_DIR").unwrap();
+        let out_dir = env!("OUT_DIR");
         // module in diffsol.ptx
         let ptx_file = format!("{}/diffsol.ptx", out_dir);
         // check if the file exists


### PR DESCRIPTION
## Summary
- use compile-time OUT_DIR instead of runtime env var for CUDA PTX loading

## Testing
- `cargo check --workspace --quiet` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68469f0aff488330a7510ae027bb9a27