### PR TITLE
bug: fix column_axpy bounds check in cuda matrix

### DIFF
--- a/diffsol/src/matrix/cuda.rs
+++ b/diffsol/src/matrix/cuda.rs
@@ -711,10 +711,10 @@ impl<T: ScalarCuda> DenseMatrix for CudaMat<T> {
     }
 
     fn column_axpy(&mut self, alpha: Self::T, j: IndexType, i: IndexType) {
-        if i > self.ncols() {
+        if i >= self.ncols() {
             panic!("Column index out of bounds");
         }
-        if j > self.ncols() {
+        if j >= self.ncols() {
             panic!("Column index out of bounds");
         }
         if i == j {


### PR DESCRIPTION
## Summary
- ensure column index equal to `ncols` is rejected for CUDA matrices

## Testing
- `cargo test --offline --features cuda` *(fails: no matching package named `cudarc` found)*

------
https://chatgpt.com/codex/tasks/task_b_6846a1027774833093ea5b32482ed5d5