### PR TITLE
Add coverage job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,9 +132,10 @@ jobs:
       if: matrix.coverage == true
       run: cargo tarpaulin --out Xml --packages diffsol ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }}
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       if: matrix.coverage == true
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: cobertura.xml
 
   book:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
         matrix:
+          coverage:
+            - false
           experimental:
             - false
           clippy:
@@ -46,28 +48,39 @@ jobs:
             - macos-latest
             - windows-latest
           include:
+            - toolchain: stable
+              os: ubuntu-latest
+              tests: false
+              clippy: false
+              experimental: true
+              basename: Coverage
+              coverage: true
             - toolchain: beta
               os: ubuntu-latest
               experimental: true
               tests: true
               basename: Tests
+              coverage: false
             - toolchain: nightly
               os: ubuntu-latest
               tests: true
               experimental: true
               basename: Tests
+              coverage: false
             - toolchain: stable
               os: ubuntu-latest
               tests: false
               clippy: true
               experimental: true
               basename: Clippy
+              coverage: false
             - toolchain: nightly
               os: ubuntu-latest
               tests: false
               rustdoc: true
               experimental: true
               basename: Rustdoc
+              coverage: false
 
     steps:
     - uses: actions/checkout@v4
@@ -112,6 +125,15 @@ jobs:
     - name: Docs - all features
       if: matrix.rustdoc == true
       run: cargo rustdoc -p diffsol ${{ env.ADDITIONAL_FEATURES_FLAGS || ''}}
+    - name: Generate coverage report
+      if: matrix.coverage == true
+      run: cargo tarpaulin --out Xml --packages diffsol ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }}
+    - name: Upload coverage
+      uses: codecov/codecov-action@v3
+      if: matrix.coverage == true
+      with:
+        files: cobertura.xml
+
   book:
     runs-on: ubuntu-latest
     steps:
@@ -130,28 +152,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.CARGO_HOME }}
-            target
-          key: diffsol-${{ runner.os }}-coverage-llvm17
-      - run: rustup update stable --no-self-update && rustup default stable
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Set features variable and install dependencies
-        run: |
-          echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features suitesparse" >> $GITHUB_ENV
-          sudo apt-get update
-          sudo apt-get install -y libsuitesparse-dev
-      - name: Generate coverage report
-        run: cargo tarpaulin --out Xml --packages diffsol ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }}
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          files: cobertura.xml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,9 +89,9 @@ jobs:
     - name: Set features variable and install dependencies (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features sundials" >> $GITHUB_ENV
+        echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features suitesparse" >> $GITHUB_ENV
         sudo apt-get update
-        sudo apt-get install -y libsuitesparse-dev libsundials-dev
+        sudo apt-get install -y libsuitesparse-dev
     - name: Set features variable and install dependencies (macOS)
       if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
       run: |
@@ -146,11 +146,11 @@ jobs:
         run: cargo install cargo-tarpaulin
       - name: Set features variable and install dependencies
         run: |
-          echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features sundials" >> $GITHUB_ENV
+          echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features suitesparse" >> $GITHUB_ENV
           sudo apt-get update
-          sudo apt-get install -y libsuitesparse-dev libsundials-dev
+          sudo apt-get install -y libsuitesparse-dev
       - name: Generate coverage report
-        run: cargo tarpaulin --out Xml ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }}
+        run: cargo tarpaulin --out Xml --packages diffsol ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }}
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,7 @@ jobs:
         path: |
           ${{ env.CARGO_HOME }}
           target
-        key: diffsol-${{ runner.os }}-${{ matrix.toolchain}}-llvm17
+        key: diffsol-${{ runner.os }}-${{ matrix.toolchain}}-coverage${{ matrix.coverage }}-llvm17
     - name: Set up Rust
       run: rustup default ${{ matrix.toolchain }} && rustup update ${{ matrix.toolchain }} --no-self-update && rustup component add clippy
     - name: Rust version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,9 @@ jobs:
         echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features suitesparse" >> $GITHUB_ENV
         sudo apt-get update
         sudo apt-get install -y libsuitesparse-dev
+    - name: Install tarpaulin
+      if: matrix.coverage == true
+      run: cargo install cargo-tarpaulin
     - name: Set features variable and install dependencies (macOS)
       if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,3 +130,28 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target
+          key: diffsol-${{ runner.os }}-coverage-llvm17
+      - run: rustup update stable --no-self-update && rustup default stable
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Set features variable and install dependencies
+        run: |
+          echo "ADDITIONAL_FEATURES_FLAGS=--features diffsl-llvm17 --features diffsl-cranelift --features sundials" >> $GITHUB_ENV
+          sudo apt-get update
+          sudo apt-get install -y libsuitesparse-dev libsundials-dev
+      - name: Generate coverage report
+        run: cargo tarpaulin --out Xml ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }}
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: cobertura.xml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 <a href="https://github.com/martinjrobins/diffsol/actions/workflows/rust.yml">
     <img src="https://github.com/martinjrobins/diffsol/actions/workflows/rust.yml/badge.svg" alt="CI build status badge">
 </a>
+<a href="https://codecov.io/gh/martinjrobins/diffsol">
+    <img src="https://codecov.io/gh/martinjrobins/diffsol/branch/main/graph/badge.svg" alt="code coverage">
+</a>
 </div>
 
 # Diffsol


### PR DESCRIPTION
## Summary
- run code coverage via cargo tarpaulin and upload to Codecov
- show coverage badge in README

## Testing
- `cargo --version`
- `cargo test --workspace --no-run` *(failed: process cancelled due to excessive runtime)*

------
https://chatgpt.com/codex/tasks/task_b_68582d95c0648330b4ba646fb4c9d724