### PR TITLE
Handle misused Newton solver API with errors

### DIFF
--- a/diffsol/src/error.rs
+++ b/diffsol/src/error.rs
@@ -49,6 +49,10 @@ pub enum NonLinearSolverError {
     NewtonDidNotConverge,
     #[error("LU solve failed")]
     LuSolveFailed,
+    #[error("Jacobian not reset before calling solve")]
+    JacobianNotReset,
+    #[error("State has wrong length: expected {expected}, got {found}")]
+    WrongStateLength { expected: usize, found: usize },
     #[error("Error: {0}")]
     Other(String),
 }

--- a/diffsol/src/nonlinear_solver/newton.rs
+++ b/diffsol/src/nonlinear_solver/newton.rs
@@ -97,10 +97,14 @@ impl<M: Matrix, Ls: LinearSolver<M>> NonLinearSolver<M> for NewtonNonlinearSolve
         convergence: &mut Convergence<M::V>,
     ) -> Result<(), DiffsolError> {
         if !self.is_jacobian_set {
-            panic!("NewtonNonlinearSolver::solve_in_place() called before reset_jacobian");
+            return Err(non_linear_solver_error!(JacobianNotReset));
         }
         if xn.len() != op.nstates() {
-            panic!("NewtonNonlinearSolver::solve() called with state of wrong size, expected {}, got {}", op.nstates(), xn.len());
+            let error = NonLinearSolverError::WrongStateLength {
+                expected: op.nstates(),
+                found: xn.len(),
+            };
+            return Err(DiffsolError::from(error));
         }
         let linear_solver = |x: &mut C::V| self.linear_solver.solve_in_place(x);
         let fun = |x: &C::V, y: &mut C::V| op.call_inplace(x, t, y);


### PR DESCRIPTION
## Summary
- convert panics in `NewtonNonlinearSolver::solve_in_place` to return `DiffsolError`
- add structured error variants for missing Jacobian and mismatched state length

## Testing
- `cargo test` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_68582fdc38948330822e845fc607f7d6