### PR TITLE
Add coverage artifact to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,6 +137,12 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: cobertura.xml
+    - name: Upload coverage artifact
+      if: matrix.coverage == true
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ matrix.os }}-${{ matrix.toolchain }}
+        path: cobertura.xml
 
   book:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update CI workflow to save coverage as artifact

## Testing
- `cargo test --quiet`
- `rustup component add rustfmt` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_6859d09a82308330b567c4041ed4c199