### PR TITLE
Fixes #176

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -149,8 +149,11 @@ jobs:
     - name: Run tests - default features
       if: matrix.tests == true
       run: cargo test --verbose
+    - name: Run tests - all features (macOS Intel)
+      if: matrix.tests == true && matrix.os == 'macos-15-intel'
+      run: cargo test --verbose ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }} --workspace --exclude neural-ode-weather-prediction
     - name: Run tests - all features
-      if: matrix.tests == true
+      if: matrix.tests == true && matrix.os != 'macos-15-intel'
       run: cargo test --verbose ${{ env.ADDITIONAL_FEATURES_FLAGS || '' }} --workspace
     - name: Clippy - all features
       if: matrix.clippy == true

--- a/examples/neural-ode-weather-prediction/Cargo.toml
+++ b/examples/neural-ode-weather-prediction/Cargo.toml
@@ -4,12 +4,20 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[features]
+default = []
+onnx = ["dep:ort", "dep:ort-sys"]
+
+[[bin]]
+name = "neural-ode-weather-prediction"
+required-features = ["onnx"]
+
 [dependencies]
 diffsol = { path = "../../diffsol" }
 nalgebra = { workspace = true }
 plotly = { workspace = true }
-ort = { workspace = true }
-ort-sys = { workspace = true }
+ort = { workspace = true, optional = true }
+ort-sys = { workspace = true, optional = true }
 ndarray = "0.16.1"
 csv = "1.3.1"
 rand = "0.9.0"


### PR DESCRIPTION
This PR downgrades `faer` to `0.21.9` with an aligned `faer-trait` version. In addition, a macos-13 x86 runner is added to the Github CI.