### PR TITLE
chore: Bump nalgebra to 34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,7 @@
 [workspace]
-members = [
-  "diffsol",
-  "examples/*",
-]
-default-members = [
-  "diffsol",
-]
-exclude = [
-  "book",
-]
+members = ["diffsol", "examples/*"]
+default-members = ["diffsol"]
+exclude = ["book"]
 resolver = "2"
 
 [workspace.package]
@@ -19,7 +12,7 @@ authors = ["Martin Robinson <martinjrobins@gmail.com>"]
 repository = "https://github.com/martinjrobins/diffsol"
 
 [workspace.dependencies]
-nalgebra = "0.33.2"
+nalgebra = "0.34.0"
 faer = "0.22.6"
 cudarc = { version = "0.16.4", default-features = false }
 


### PR DESCRIPTION
To make `diffsol` compatible with the latest release of `nalgebra`.