### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+
+permissions:
+  contents: read
       
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Potential fix for [https://github.com/martinjrobins/diffsol/security/code-scanning/1](https://github.com/martinjrobins/diffsol/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/rust.yml` so all jobs inherit minimal token access unless overridden.  
Best single fix here: add:

```yml
permissions:
  contents: read
```

directly after the `on:` section (before `env:` is a clean location). This satisfies checkout needs and enforces least privilege workflow-wide without changing job logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
