### PR TITLE
feat: make rayon an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ faer = { version = "0.24", default-features = false, features = [
 ] }
 faer-traits = "0.24"
 cudarc = { version = "0.19", default-features = false }
-diffsl = { version = "0.11.9", features = ["rayon"] }
+diffsl = { version = "0.11.9" }
 
 plotly = { version = "0.14" }
 argmin = { version = "0.11.0" }

--- a/diffsol-c/Cargo.toml
+++ b/diffsol-c/Cargo.toml
@@ -12,8 +12,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["diffsl-external-dynamic"]
+default = ["diffsl-external-dynamic", "rayon"]
 wasm = ["getrandom/js"]
+rayon = ["diffsol/rayon", "faer/rayon"]
 external = []
 external-dynamic = []
 diffsl-external-f64 = [
@@ -43,7 +44,7 @@ suitesparse = ["diffsol/suitesparse"]
 
 [dependencies]
 diffsl = { workspace = true }
-diffsol = { path = "../diffsol", version = "0.14.0", features = ["diffsl"] }
+diffsol = { path = "../diffsol", version = "0.14.0", default-features = false, features = ["nalgebra", "faer", "diffsl"] }
 dlmalloc = { version = "0.2", features = ["global"] }
 nalgebra = { workspace = true, features = ["std"] }
 ndarray = { version = "0.17.2" }
@@ -52,12 +53,11 @@ schemars = "1.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 paste = { workspace = true }
+faer = { workspace = true }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-faer = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 getrandom = { version = "0.2", optional = true }
-faer = { workspace = true, features = ["rayon"] }

--- a/diffsol-c/Cargo.toml
+++ b/diffsol-c/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["diffsl-external-dynamic", "rayon"]
+default = ["diffsl-external-dynamic"]
 wasm = ["getrandom/js"]
 rayon = ["diffsol/rayon", "faer/rayon"]
 external = []

--- a/diffsol/Cargo.toml
+++ b/diffsol/Cargo.toml
@@ -12,9 +12,10 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["nalgebra", "faer"]
+default = ["nalgebra", "faer", "rayon"]
 faer = []
 nalgebra = []
+rayon = ["faer/rayon", "diffsl?/rayon"]
 cuda = ["dep:cudarc"]
 sundials = ["suitesparse_sys", "bindgen", "cc"]
 suitesparse = ["suitesparse_sys"]
@@ -57,11 +58,6 @@ cudarc = { workspace = true, optional = true, default-features = false, features
 ] }
 log = "0.4.29"
 serde_json = { workspace = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-faer = { workspace = true, features = ["rayon"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 faer = { workspace = true }
 
 [dev-dependencies]

--- a/diffsol/Cargo.toml
+++ b/diffsol/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["nalgebra", "faer", "rayon"]
+default = ["nalgebra", "faer"]
 faer = []
 nalgebra = []
 rayon = ["faer/rayon", "diffsl?/rayon"]


### PR DESCRIPTION
On wasm32 the rayon faer feature is silently skipped by the existing target-gated dep declaration. I'd like to make this opt-in via a `rayon` feature so non-wasm consumers can also drop it.

<details>
<summary><h3>AI-written details</h3></summary>

## Summary
- Add a `rayon` cargo feature to both `diffsol` and `diffsol-c`. The feature is opt-in (not in `default`) so the wasm build continues to work without `default-features = false`.
- In `diffsol`, the feature forwards to `faer/rayon` and (weakly) to `diffsl?/rayon`, so the `diffsl` optional dep is still not pulled in unless explicitly enabled elsewhere.
- In `diffsol-c`, the feature forwards to `diffsol/rayon` and `faer/rayon`. The `diffsol` path dep is switched to `default-features = false` plus an explicit feature list (`nalgebra`, `faer`, `diffsl`) so it inherits the rayon choice from diffsol-c.
- Collapse the two target-gated `faer` declarations (which differed only in the presence of the `rayon` feature) into a single base dep on both crates.
- In the workspace `Cargo.toml`, drop the always-on `features = ["rayon"]` from the `diffsl` workspace dep, so the per-crate `rayon` feature is the single point of truth.

## Behavior change
- Previously, non-wasm builds of `diffsol` got `faer/rayon` automatically via the target-gated dep. With this PR they no longer do unless `--features rayon` is passed. Consumers who want the old behavior should add `rayon` to their feature list.
- wasm32 behavior is unchanged (no rayon, as before).

## Test plan
- [ ] `cargo check -p diffsol` (default features) builds.
- [ ] `cargo check -p diffsol --features rayon` builds.
- [ ] `cargo check -p diffsol --features "rayon,diffsl-cranelift"` builds; `cargo tree --invert rayon` shows rayon reaching `diffsl` only through `diffsol`'s rayon feature.
- [ ] `cargo check -p diffsol-c` and `--features rayon` both build.
- [ ] `cargo check -p population-dynamics-wasm-yew --target wasm32-unknown-unknown` builds (the case that drove the first CI failure on this PR).

## Notes
- `diffsl?/rayon` uses the [weak dependency feature syntax](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) (Cargo 1.60+), so enabling `rayon` does not pull `diffsl` in by itself.
- No source code under `src/` references rayon directly; the change is purely in feature plumbing.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>