### PR TITLE
Add `inner_mut` to Matrix trait for direct CSC access

### DIFF
--- a/diffsol/src/matrix/cuda.rs
+++ b/diffsol/src/matrix/cuda.rs
@@ -787,6 +787,9 @@ impl<T: ScalarCuda> Matrix for CudaMat<T> {
     fn context(&self) -> &Self::C {
         &self.context
     }
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.data
+    }
 
     fn gather(&mut self, other: &Self, indices: &<Self::V as Vector>::Index) {
         let f = self.context.function::<T>("vec_gather");

--- a/diffsol/src/matrix/dense_faer_serial.rs
+++ b/diffsol/src/matrix/dense_faer_serial.rs
@@ -276,6 +276,9 @@ impl<T: FaerScalar> Matrix for FaerMat<T> {
     fn context(&self) -> &Self::C {
         &self.context
     }
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.data
+    }
 
     fn gather(&mut self, other: &Self, indices: &<Self::V as Vector>::Index) {
         assert_eq!(indices.len(), self.nrows() * self.ncols());

--- a/diffsol/src/matrix/dense_nalgebra_serial.rs
+++ b/diffsol/src/matrix/dense_nalgebra_serial.rs
@@ -211,6 +211,9 @@ impl<T: NalgebraScalar> Matrix for NalgebraMat<T> {
     fn context(&self) -> &Self::C {
         &self.context
     }
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.data
+    }
 
     fn set_data_with_indices(
         &mut self,

--- a/diffsol/src/matrix/mod.rs
+++ b/diffsol/src/matrix/mod.rs
@@ -180,6 +180,9 @@ pub trait Matrix:
     /// Get the context associated with this matrix (for device placement, memory management, etc.).
     fn context(&self) -> &Self::C;
 
+    /// Get a mutable reference to the inner representation of the matrix.
+    fn inner_mut(&mut self) -> &mut Self::Inner;
+
     /// Returns true if this matrix is stored in a sparse format
     fn is_sparse() -> bool {
         Self::zeros(1, 1, Default::default()).sparsity().is_some()

--- a/diffsol/src/matrix/sparse_faer.rs
+++ b/diffsol/src/matrix/sparse_faer.rs
@@ -259,6 +259,9 @@ impl<T: FaerScalar> Matrix for FaerSparseMat<T> {
     fn context(&self) -> &FaerContext {
         &self.context
     }
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.data
+    }
 
     fn gather(&mut self, other: &Self, indices: &<Self::V as Vector>::Index) {
         let dst_data = self.data.val_mut();
@@ -415,6 +418,46 @@ mod tests {
             assert_eq!(j, triplet.1);
             assert_eq!(val, triplet.2);
         }
+    }
+
+    #[test]
+    fn test_inner_mut() {
+        use crate::{FaerVec, FaerVecIndex, Vector, VectorIndex};
+
+        // CSC data-array order: column-major, ascending row within each column.
+        let triplets = vec![
+            (0, 0, 1.0),
+            (2, 0, 2.0),
+            (1, 1, 3.0),
+            (0, 2, 4.0),
+            (2, 2, 5.0),
+        ];
+        let mut mat =
+            FaerSparseMat::<f64>::try_from_triplets(3, 3, triplets.clone(), Default::default())
+                .unwrap();
+
+        assert_eq!(mat.inner_mut().val_mut().len(), triplets.len());
+
+        let new_values = [10.0, 11.0, 12.0, 13.0, 14.0];
+        mat.inner_mut().val_mut().copy_from_slice(&new_values);
+        let got: Vec<(usize, usize, f64)> = mat.triplet_iter().collect();
+        let expected: Vec<(usize, usize, f64)> = triplets
+            .iter()
+            .zip(new_values.iter())
+            .map(|(&(i, j, _), &v)| (i, j, v))
+            .collect();
+        assert_eq!(got, expected);
+
+        let mut via_set_data =
+            FaerSparseMat::<f64>::try_from_triplets(3, 3, triplets, Default::default()).unwrap();
+        let nnz = new_values.len();
+        let identity = FaerVecIndex::from_vec((0..nnz).collect(), Default::default());
+        let data = FaerVec::from_vec(new_values.to_vec(), Default::default());
+        via_set_data.set_data_with_indices(&identity, &identity, &data);
+        assert_eq!(
+            mat.inner_mut().val_mut(),
+            via_set_data.inner_mut().val_mut()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Exposes direct mutable access to the `Matrix` trait so a caller can write matrix values in place without going through `set_data_with_indices`. 

The underlying reason here is that `set_data_with_indices(dst, src, data)` fits when diffsol owns the index mapping, but a caller that owns its Jacobian assembly via its own colouring, CSC scatter map, and value computation, otherwise has to marshal into that ABI, allocate an intermediate source buffer, and copy twice. Direct access lets it write (and accumulate, e.g. `J = df/dy − cj·M`) straight into the store using its own map.