### PR TITLE
refactor(statistics): `BdfStatistics` to `OdeSolverStatistics`

### DIFF
--- a/diffsol/src/ode_solver/bdf.rs
+++ b/diffsol/src/ode_solver/bdf.rs
@@ -1799,13 +1799,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem_diffsl::<M, diffsl::LlvmModule>(false);
         let mut s = problem.bdf_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 14
         number_of_steps: 52
         number_of_error_test_failures: 1
         number_of_nonlinear_solver_iterations: 164
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 1
+        number_of_linear_solver_setups_from_step_success: 12
+        ");
     }
 
     #[cfg(feature = "diffsl-llvm")]
@@ -2054,13 +2059,18 @@ mod test {
         soln.rtol = problem.rtol;
         let mut s = problem.bdf_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 23
         number_of_steps: 47
         number_of_error_test_failures: 8
         number_of_nonlinear_solver_iterations: 119
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 8
+        number_of_linear_solver_setups_from_step_success: 14
+        ");
     }
 
     #[test]

--- a/diffsol/src/ode_solver/bdf.rs
+++ b/diffsol/src/ode_solver/bdf.rs
@@ -26,6 +26,14 @@ use super::jacobian_update::SolverState;
 use super::method::AugmentedOdeSolverMethod;
 use super::sensitivities::SensitivitiesOdeSolverMethod;
 
+/// Solver statistics for the BDF method (the struct is also reused by the SDIRK and
+/// explicit Runge-Kutta solvers).
+///
+/// The `number_of_linear_solver_setups_from_*` fields attribute every Jacobian/LU refresh counted in
+/// [`number_of_linear_solver_setups`](Self::number_of_linear_solver_setups) to the solver
+/// condition that triggered it; when populated they sum exactly to it. Only the BDF solver
+/// populates them — they remain `0` for SDIRK / explicit RK, which do not break their setups
+/// down by cause.
 #[derive(Clone, Debug, Serialize, Default)]
 pub struct BdfStatistics {
     pub number_of_linear_solver_setups: usize,
@@ -33,6 +41,16 @@ pub struct BdfStatistics {
     pub number_of_error_test_failures: usize,
     pub number_of_nonlinear_solver_iterations: usize,
     pub number_of_nonlinear_solver_fails: usize,
+    /// Jacobian/LU setups triggered by checkpoint or reinitialisation.
+    pub number_of_linear_solver_setups_from_checkpoint: usize,
+    /// Jacobian/LU setups triggered by a first nonlinear convergence failure.
+    pub number_of_linear_solver_setups_from_first_convergence_fail: usize,
+    /// Jacobian/LU setups triggered by a second nonlinear convergence failure.
+    pub number_of_linear_solver_setups_from_second_convergence_fail: usize,
+    /// Jacobian/LU setups triggered by a local error test failure.
+    pub number_of_linear_solver_setups_from_error_test_fail: usize,
+    /// Jacobian/LU setups triggered by the normal step-success heuristic.
+    pub number_of_linear_solver_setups_from_step_success: usize,
 }
 
 impl Display for BdfStatistics {
@@ -363,7 +381,14 @@ where
             alpha,
             error_const2,
             u,
-            statistics: BdfStatistics::default(),
+            statistics: BdfStatistics {
+                number_of_linear_solver_setups_from_checkpoint: if integrate_main_eqn {
+                    1
+                } else {
+                    0
+                },
+                ..BdfStatistics::default()
+            },
             state,
             tstop: None,
             root_finder,
@@ -467,29 +492,66 @@ where
     }
 
     fn _jacobian_updates(&mut self, c: Eqn::T, state: SolverState) {
-        if self.jacobian_update.check_rhs_jacobian_update(c, &state) {
-            if let Some(op) = self.op.as_mut() {
+        let did_update = if self.jacobian_update.check_rhs_jacobian_update(c, &state) {
+            let did_reset = if let Some(op) = self.op.as_mut() {
                 op.set_jacobian_is_stale();
                 self.nonlinear_solver
                     .reset_jacobian(op, &self.state.y, self.state.t);
+                true
             } else if let Some(s_op) = self.s_op.as_mut() {
                 s_op.set_jacobian_is_stale();
                 self.nonlinear_solver
                     .reset_jacobian(s_op, &self.state.s[0], self.state.t);
-            }
+                true
+            } else {
+                false
+            };
             self.jacobian_update.update_rhs_jacobian(c);
             self.jacobian_update.update_jacobian(c);
             self.convergence.reset_eta();
+            did_reset
         } else if self.jacobian_update.check_jacobian_update(c, &state) {
-            if let Some(op) = self.op.as_mut() {
+            let did_reset = if let Some(op) = self.op.as_mut() {
                 self.nonlinear_solver
                     .reset_jacobian(op, &self.state.y, self.state.t);
+                true
             } else if let Some(s_op) = self.s_op.as_mut() {
                 self.nonlinear_solver
                     .reset_jacobian(s_op, &self.state.s[0], self.state.t);
-            }
+                true
+            } else {
+                false
+            };
             self.jacobian_update.update_jacobian(c);
             self.convergence.reset_eta();
+            did_reset
+        } else {
+            false
+        };
+
+        if did_update {
+            match state {
+                SolverState::Checkpoint => {
+                    self.statistics
+                        .number_of_linear_solver_setups_from_checkpoint += 1;
+                }
+                SolverState::FirstConvergenceFail => {
+                    self.statistics
+                        .number_of_linear_solver_setups_from_first_convergence_fail += 1;
+                }
+                SolverState::SecondConvergenceFail => {
+                    self.statistics
+                        .number_of_linear_solver_setups_from_second_convergence_fail += 1;
+                }
+                SolverState::ErrorTestFail => {
+                    self.statistics
+                        .number_of_linear_solver_setups_from_error_test_fail += 1;
+                }
+                SolverState::StepSuccess => {
+                    self.statistics
+                        .number_of_linear_solver_setups_from_step_success += 1;
+                }
+            }
         }
     }
 
@@ -1458,11 +1520,6 @@ where
         }
 
         // update statistics
-        if let Some(op) = self.op.as_ref() {
-            self.statistics.number_of_linear_solver_setups = op.number_of_jac_evals();
-        } else if let Some(s_op) = self.s_op.as_ref() {
-            self.statistics.number_of_linear_solver_setups = s_op.number_of_jac_evals();
-        }
         self.statistics.number_of_steps += 1;
         self.jacobian_update.step();
 
@@ -1549,6 +1606,15 @@ where
                 );
                 self._jacobian_updates(new_h * self.alpha[order], SolverState::StepSuccess);
             }
+        }
+
+        // Record the LU-setup total after the post-step (step-success) jacobian update in the
+        // order-change block above, so it includes the refresh on the final accepted step and
+        // the per-cause `number_of_linear_solver_setups_from_*` fields sum to it exactly.
+        if let Some(op) = self.op.as_ref() {
+            self.statistics.number_of_linear_solver_setups = op.number_of_jac_evals();
+        } else if let Some(s_op) = self.s_op.as_ref() {
+            self.statistics.number_of_linear_solver_setups = s_op.number_of_jac_evals();
         }
 
         // check for root within accepted step
@@ -1679,13 +1745,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 12
         number_of_steps: 49
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 50
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 11
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 52
         number_of_jac_muls: 2
@@ -1725,13 +1796,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 12
         number_of_steps: 49
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 50
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 11
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 52
         number_of_jac_muls: 2
@@ -1745,13 +1821,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         let mut s = problem.bdf_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 14
         number_of_steps: 52
         number_of_error_test_failures: 1
         number_of_nonlinear_solver_iterations: 164
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 1
+        number_of_linear_solver_setups_from_step_success: 12
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.statistics(), @r###"
         number_of_calls: 56
         number_of_jac_muls: 114
@@ -1959,13 +2040,18 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_problem::<M>(false);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 18
         number_of_steps: 38
         number_of_error_test_failures: 5
         number_of_nonlinear_solver_iterations: 49
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 5
+        number_of_linear_solver_setups_from_step_success: 12
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 53
         number_of_jac_muls: 6
@@ -1986,13 +2072,18 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_problem_sens::<M>();
         let mut s = problem.bdf_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 23
         number_of_steps: 47
         number_of_error_test_failures: 8
         number_of_nonlinear_solver_iterations: 119
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 8
+        number_of_linear_solver_setups_from_step_success: 14
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 68
         number_of_jac_muls: 66
@@ -2033,13 +2124,18 @@ mod test {
         let (problem, soln) = robertson::<M>(false);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        number_of_linear_solver_setups: 79
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
+        number_of_linear_solver_setups: 80
         number_of_steps: 328
         number_of_error_test_failures: 7
         number_of_nonlinear_solver_iterations: 648
         number_of_nonlinear_solver_fails: 13
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 12
+        number_of_linear_solver_setups_from_second_convergence_fail: 1
+        number_of_linear_solver_setups_from_error_test_fail: 7
+        number_of_linear_solver_setups_from_step_success: 59
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 651
         number_of_jac_muls: 45
@@ -2100,13 +2196,18 @@ mod test {
         problem.ode_options.max_nonlinear_solver_failures = 70;
         let mut s = problem.bdf_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 92
         number_of_steps: 319
         number_of_error_test_failures: 4
         number_of_nonlinear_solver_iterations: 1941
         number_of_nonlinear_solver_fails: 28
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 26
+        number_of_linear_solver_setups_from_second_convergence_fail: 2
+        number_of_linear_solver_setups_from_error_test_fail: 4
+        number_of_linear_solver_setups_from_step_success: 59
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 575
         number_of_jac_muls: 1522
@@ -2120,13 +2221,18 @@ mod test {
         let (problem, soln) = robertson::<M>(true);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        number_of_linear_solver_setups: 79
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
+        number_of_linear_solver_setups: 80
         number_of_steps: 328
         number_of_error_test_failures: 7
         number_of_nonlinear_solver_iterations: 648
         number_of_nonlinear_solver_fails: 13
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 12
+        number_of_linear_solver_setups_from_second_convergence_fail: 1
+        number_of_linear_solver_setups_from_error_test_fail: 7
+        number_of_linear_solver_setups_from_step_success: 59
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 651
         number_of_jac_muls: 48
@@ -2140,13 +2246,18 @@ mod test {
         let (problem, soln) = robertson_ode::<M>(false, 3);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 81
         number_of_steps: 400
         number_of_error_test_failures: 4
         number_of_nonlinear_solver_iterations: 828
         number_of_nonlinear_solver_fails: 4
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 4
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 4
+        number_of_linear_solver_setups_from_step_success: 72
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 830
         number_of_jac_muls: 81
@@ -2160,13 +2271,18 @@ mod test {
         let (problem, soln) = robertson_ode_with_sens::<M>(false);
         let mut s = problem.bdf_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        number_of_linear_solver_setups: 218
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
+        number_of_linear_solver_setups: 219
         number_of_steps: 669
         number_of_error_test_failures: 110
         number_of_nonlinear_solver_iterations: 3785
         number_of_nonlinear_solver_fails: 15
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 14
+        number_of_linear_solver_setups_from_second_convergence_fail: 1
+        number_of_linear_solver_setups_from_error_test_fail: 110
+        number_of_linear_solver_setups_from_step_success: 93
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 1035
         number_of_jac_muls: 2845
@@ -2180,13 +2296,18 @@ mod test {
         let (problem, soln) = dydt_y2_problem::<M>(false, 10);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 28
         number_of_steps: 156
         number_of_error_test_failures: 3
         number_of_nonlinear_solver_iterations: 283
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 3
+        number_of_linear_solver_setups_from_step_success: 24
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 285
         number_of_jac_muls: 30
@@ -2200,13 +2321,18 @@ mod test {
         let (problem, soln) = dydt_y2_problem::<M>(true, 10);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 28
         number_of_steps: 156
         number_of_error_test_failures: 3
         number_of_nonlinear_solver_iterations: 283
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 3
+        number_of_linear_solver_setups_from_step_success: 24
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 285
         number_of_jac_muls: 13
@@ -2220,13 +2346,18 @@ mod test {
         let (problem, soln) = gaussian_decay_problem::<M>(false, 10);
         let mut s = problem.bdf::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 17
         number_of_steps: 64
         number_of_error_test_failures: 3
         number_of_nonlinear_solver_iterations: 92
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 3
+        number_of_linear_solver_setups_from_step_success: 13
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 94
         number_of_jac_muls: 20
@@ -2240,13 +2371,18 @@ mod test {
         let (problem, soln) = head2d_problem::<FaerSparseMat<f64>, 10>();
         let mut s = problem.bdf::<FaerSparseLU<f64>>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
-        number_of_linear_solver_setups: 21
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
+        number_of_linear_solver_setups: 22
         number_of_steps: 168
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 180
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 21
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 183
         number_of_jac_muls: 128
@@ -2271,13 +2407,18 @@ mod test {
         let (problem, soln) = foodweb_problem::<FaerSparseMat<f64>, 10>();
         let mut s = problem.bdf::<FaerSparseLU<f64>>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 41
         number_of_steps: 167
         number_of_error_test_failures: 2
         number_of_nonlinear_solver_iterations: 451
         number_of_nonlinear_solver_fails: 13
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 13
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 2
+        number_of_linear_solver_setups_from_step_success: 25
+        ");
     }
 
     #[cfg(feature = "diffsl-llvm")]

--- a/diffsol/src/ode_solver/bdf.rs
+++ b/diffsol/src/ode_solver/bdf.rs
@@ -1,6 +1,6 @@
 use log::{debug, info, trace};
+use std::cell::Ref;
 use std::ops::AddAssign;
-use std::{cell::Ref, fmt::Display};
 
 use crate::{
     error::{DiffsolError, OdeSolverError},
@@ -9,7 +9,6 @@ use crate::{
 };
 
 use num_traits::{abs, FromPrimitive, One, Pow, Signed, ToPrimitive, Zero};
-use serde::Serialize;
 
 use crate::ode_solver_error;
 use crate::{
@@ -25,39 +24,7 @@ use super::config::BdfConfig;
 use super::jacobian_update::SolverState;
 use super::method::AugmentedOdeSolverMethod;
 use super::sensitivities::SensitivitiesOdeSolverMethod;
-
-/// Solver statistics for the BDF method (the struct is also reused by the SDIRK and
-/// explicit Runge-Kutta solvers).
-///
-/// The `number_of_linear_solver_setups_from_*` fields attribute every Jacobian/LU refresh counted in
-/// [`number_of_linear_solver_setups`](Self::number_of_linear_solver_setups) to the solver
-/// condition that triggered it; when populated they sum exactly to it. Only the BDF solver
-/// populates them — they remain `0` for SDIRK / explicit RK, which do not break their setups
-/// down by cause.
-#[derive(Clone, Debug, Serialize, Default)]
-pub struct BdfStatistics {
-    pub number_of_linear_solver_setups: usize,
-    pub number_of_steps: usize,
-    pub number_of_error_test_failures: usize,
-    pub number_of_nonlinear_solver_iterations: usize,
-    pub number_of_nonlinear_solver_fails: usize,
-    /// Jacobian/LU setups triggered by checkpoint or reinitialisation.
-    pub number_of_linear_solver_setups_from_checkpoint: usize,
-    /// Jacobian/LU setups triggered by a first nonlinear convergence failure.
-    pub number_of_linear_solver_setups_from_first_convergence_fail: usize,
-    /// Jacobian/LU setups triggered by a second nonlinear convergence failure.
-    pub number_of_linear_solver_setups_from_second_convergence_fail: usize,
-    /// Jacobian/LU setups triggered by a local error test failure.
-    pub number_of_linear_solver_setups_from_error_test_fail: usize,
-    /// Jacobian/LU setups triggered by the normal step-success heuristic.
-    pub number_of_linear_solver_setups_from_step_success: usize,
-}
-
-impl Display for BdfStatistics {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string_pretty(self).unwrap())
-    }
-}
+use super::OdeSolverStatistics;
 
 impl<'a, M, Eqn, Nls, AugEqn> AugmentedOdeSolverMethod<'a, Eqn, AugEqn>
     for Bdf<'a, Eqn, Nls, M, AugEqn>
@@ -172,7 +139,7 @@ pub struct Bdf<
     alpha: Vec<Eqn::T>,
     gamma: Vec<Eqn::T>,
     error_const2: Vec<Eqn::T>,
-    statistics: BdfStatistics,
+    statistics: OdeSolverStatistics,
     state: BdfState<Eqn::V, M>,
     tstop: Option<Eqn::T>,
     root_finder: Option<RootFinder<Eqn::V>>,
@@ -226,7 +193,7 @@ where
             alpha: self.alpha.clone(),
             gamma: self.gamma.clone(),
             error_const2: self.error_const2.clone(),
-            statistics: BdfStatistics::default(),
+            statistics: OdeSolverStatistics::default(),
             state: self.state.clone(),
             tstop: self.tstop,
             root_finder: self.root_finder.clone(),
@@ -381,13 +348,13 @@ where
             alpha,
             error_const2,
             u,
-            statistics: BdfStatistics {
+            statistics: OdeSolverStatistics {
                 number_of_linear_solver_setups_from_checkpoint: if integrate_main_eqn {
                     1
                 } else {
                     0
                 },
-                ..BdfStatistics::default()
+                ..OdeSolverStatistics::default()
             },
             state,
             tstop: None,
@@ -456,7 +423,7 @@ where
         Ok(ret)
     }
 
-    pub fn get_statistics(&self) -> &BdfStatistics {
+    pub fn get_statistics(&self) -> &OdeSolverStatistics {
         &self.statistics
     }
 
@@ -530,28 +497,7 @@ where
         };
 
         if did_update {
-            match state {
-                SolverState::Checkpoint => {
-                    self.statistics
-                        .number_of_linear_solver_setups_from_checkpoint += 1;
-                }
-                SolverState::FirstConvergenceFail => {
-                    self.statistics
-                        .number_of_linear_solver_setups_from_first_convergence_fail += 1;
-                }
-                SolverState::SecondConvergenceFail => {
-                    self.statistics
-                        .number_of_linear_solver_setups_from_second_convergence_fail += 1;
-                }
-                SolverState::ErrorTestFail => {
-                    self.statistics
-                        .number_of_linear_solver_setups_from_error_test_fail += 1;
-                }
-                SolverState::StepSuccess => {
-                    self.statistics
-                        .number_of_linear_solver_setups_from_step_success += 1;
-                }
-            }
+            self.statistics.record_linear_solver_setup(state);
         }
     }
 
@@ -1608,9 +1554,7 @@ where
             }
         }
 
-        // Record the LU-setup total after the post-step (step-success) jacobian update in the
-        // order-change block above, so it includes the refresh on the final accepted step and
-        // the per-cause `number_of_linear_solver_setups_from_*` fields sum to it exactly.
+        // Record the LU-setup total after the post-step jacobian update
         if let Some(op) = self.op.as_ref() {
             self.statistics.number_of_linear_solver_setups = op.number_of_jac_evals();
         } else if let Some(s_op) = self.s_op.as_ref() {

--- a/diffsol/src/ode_solver/bdf.rs
+++ b/diffsol/src/ode_solver/bdf.rs
@@ -349,6 +349,7 @@ where
             error_const2,
             u,
             statistics: OdeSolverStatistics {
+                number_of_linear_solver_setups: if integrate_main_eqn { 1 } else { 0 },
                 number_of_linear_solver_setups_from_checkpoint: if integrate_main_eqn {
                     1
                 } else {
@@ -406,6 +407,8 @@ where
             ret.nonlinear_solver.set_problem(&bdf_callable);
             ret.nonlinear_solver
                 .reset_jacobian(&bdf_callable, &ret.state.s[0], ret.state.t);
+            ret.statistics
+                .record_linear_solver_setup(SolverState::Checkpoint);
             Some(bdf_callable)
         };
 
@@ -1552,13 +1555,6 @@ where
                 );
                 self._jacobian_updates(new_h * self.alpha[order], SolverState::StepSuccess);
             }
-        }
-
-        // Record the LU-setup total after the post-step jacobian update
-        if let Some(op) = self.op.as_ref() {
-            self.statistics.number_of_linear_solver_setups = op.number_of_jac_evals();
-        } else if let Some(s_op) = self.s_op.as_ref() {
-            self.statistics.number_of_linear_solver_setups = s_op.number_of_jac_evals();
         }
 
         // check for root within accepted step

--- a/diffsol/src/ode_solver/explicit_rk.rs
+++ b/diffsol/src/ode_solver/explicit_rk.rs
@@ -394,13 +394,18 @@ mod test {
         let (problem, soln) = heat1d_diffsl_problem::<M, diffsl::LlvmModule, 10>();
         let mut s = problem.tsit45().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 0
         number_of_steps: 93
         number_of_error_test_failures: 11
         number_of_nonlinear_solver_iterations: 0
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 0
         number_of_jac_muls: 0
@@ -415,13 +420,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<crate::CudaMat<f64>>(false);
         let mut s = problem.tsit45().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 0
         number_of_steps: 9
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 0
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 56
         number_of_jac_muls: 0

--- a/diffsol/src/ode_solver/explicit_rk.rs
+++ b/diffsol/src/ode_solver/explicit_rk.rs
@@ -3,7 +3,7 @@ use super::method::AugmentedOdeSolverMethod;
 use super::runge_kutta::Rk;
 use super::sensitivities::SensitivitiesOdeSolverMethod;
 use crate::error::DiffsolError;
-use crate::ode_solver::bdf::BdfStatistics;
+use crate::ode_solver::OdeSolverStatistics;
 use crate::vector::VectorRef;
 use crate::NoAug;
 use crate::OdeEquationsImplicitSens;
@@ -138,7 +138,7 @@ where
         })
     }
 
-    pub fn get_statistics(&self) -> &BdfStatistics {
+    pub fn get_statistics(&self) -> &OdeSolverStatistics {
         self.rk.get_statistics()
     }
 }

--- a/diffsol/src/ode_solver/explicit_rk.rs
+++ b/diffsol/src/ode_solver/explicit_rk.rs
@@ -359,13 +359,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         let mut s = problem.tsit45().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 0
         number_of_steps: 9
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 0
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 56
         number_of_jac_muls: 0
@@ -430,13 +435,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         let mut s = problem.tsit45_sens().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 0
         number_of_steps: 10
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 0
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 62
         number_of_jac_muls: 122

--- a/diffsol/src/ode_solver/mod.rs
+++ b/diffsol/src/ode_solver/mod.rs
@@ -18,6 +18,62 @@ pub mod solution;
 pub mod state;
 pub mod tableau;
 
+use serde::Serialize;
+use std::fmt::Display;
+
+use crate::ode_solver::jacobian_update::SolverState;
+
+/// Solver statistics shared by all ODE solver methods.
+#[derive(Clone, Debug, Serialize, Default)]
+pub struct OdeSolverStatistics {
+    /// Total number of Jacobian/LU factorisation setups performed.
+    pub number_of_linear_solver_setups: usize,
+    /// Number of time steps taken by the solver.
+    pub number_of_steps: usize,
+    /// Number of local error test failures (steps rejected for excessive local error).
+    pub number_of_error_test_failures: usize,
+    /// Total number of nonlinear (Newton) solver iterations across all steps.
+    pub number_of_nonlinear_solver_iterations: usize,
+    /// Number of nonlinear (Newton) solver convergence failures.
+    pub number_of_nonlinear_solver_fails: usize,
+    /// Jacobian/LU setups triggered by checkpoint or reinitialisation.
+    pub number_of_linear_solver_setups_from_checkpoint: usize,
+    /// Jacobian/LU setups triggered by a first nonlinear convergence failure.
+    pub number_of_linear_solver_setups_from_first_convergence_fail: usize,
+    /// Jacobian/LU setups triggered by a second nonlinear convergence failure.
+    pub number_of_linear_solver_setups_from_second_convergence_fail: usize,
+    /// Jacobian/LU setups triggered by a local error test failure.
+    pub number_of_linear_solver_setups_from_error_test_fail: usize,
+    /// Jacobian/LU setups triggered by the normal step-success heuristic.
+    pub number_of_linear_solver_setups_from_step_success: usize,
+}
+
+impl OdeSolverStatistics {
+    /// Attribute a Jacobian/LU setup to the solver condition that triggered it,
+    /// incrementing the matching per-cause counter.
+    pub(crate) fn record_linear_solver_setup(&mut self, cause: SolverState) {
+        match cause {
+            SolverState::Checkpoint => self.number_of_linear_solver_setups_from_checkpoint += 1,
+            SolverState::FirstConvergenceFail => {
+                self.number_of_linear_solver_setups_from_first_convergence_fail += 1
+            }
+            SolverState::SecondConvergenceFail => {
+                self.number_of_linear_solver_setups_from_second_convergence_fail += 1
+            }
+            SolverState::ErrorTestFail => {
+                self.number_of_linear_solver_setups_from_error_test_fail += 1
+            }
+            SolverState::StepSuccess => self.number_of_linear_solver_setups_from_step_success += 1,
+        }
+    }
+}
+
+impl Display for OdeSolverStatistics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string_pretty(self).unwrap())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::rc::Rc;

--- a/diffsol/src/ode_solver/mod.rs
+++ b/diffsol/src/ode_solver/mod.rs
@@ -26,7 +26,7 @@ use crate::ode_solver::jacobian_update::SolverState;
 /// Solver statistics shared by all ODE solver methods.
 #[derive(Clone, Debug, Serialize, Default)]
 pub struct OdeSolverStatistics {
-    /// Total number of Jacobian/LU factorisation setups performed.
+    /// Total Jacobian/LU setups (CVODE `nsetups`); sum of the per-cause counters below.
     pub number_of_linear_solver_setups: usize,
     /// Number of time steps taken by the solver.
     pub number_of_steps: usize,
@@ -49,9 +49,9 @@ pub struct OdeSolverStatistics {
 }
 
 impl OdeSolverStatistics {
-    /// Attribute a Jacobian/LU setup to the solver condition that triggered it,
-    /// incrementing the matching per-cause counter.
+    /// Record a Jacobian/LU setup, incrementing the total and the per-cause counter.
     pub(crate) fn record_linear_solver_setup(&mut self, cause: SolverState) {
+        self.number_of_linear_solver_setups += 1;
         match cause {
             SolverState::Checkpoint => self.number_of_linear_solver_setups_from_checkpoint += 1,
             SolverState::FirstConvergenceFail => {

--- a/diffsol/src/ode_solver/runge_kutta.rs
+++ b/diffsol/src/ode_solver/runge_kutta.rs
@@ -17,7 +17,8 @@ use log::info;
 use log::trace;
 use num_traits::{abs, FromPrimitive, One, Pow, ToPrimitive, Zero};
 
-use super::bdf::BdfStatistics;
+use super::jacobian_update::SolverState;
+use super::OdeSolverStatistics;
 use std::ops::{MulAssign, SubAssign};
 
 /// A Runge-Kutta method.
@@ -38,7 +39,7 @@ where
     tableau: Tableau<M>,
     state: RkState<Eqn::V>,
     a_rows: Vec<Eqn::V>,
-    statistics: BdfStatistics,
+    statistics: OdeSolverStatistics,
     root_finder: Option<RootFinder<Eqn::V>>,
     tstop: Option<Eqn::T>,
     diff: M,
@@ -115,7 +116,7 @@ where
         integrate_main_eqn: bool,
     ) -> Result<Self, DiffsolError> {
         // update statistics
-        let statistics = BdfStatistics::default();
+        let statistics = OdeSolverStatistics::default();
 
         state.check_consistent_with_problem(problem)?;
 
@@ -348,8 +349,12 @@ where
         &self.tableau
     }
 
-    pub(crate) fn get_statistics(&self) -> &BdfStatistics {
+    pub(crate) fn get_statistics(&self) -> &OdeSolverStatistics {
         &self.statistics
+    }
+
+    pub(crate) fn statistics_mut(&mut self) -> &mut OdeSolverStatistics {
+        &mut self.statistics
     }
 
     pub(crate) fn set_state(&mut self, state: RkState<Eqn::V>) {
@@ -635,6 +640,8 @@ where
             );
             if !nonlinear_solver.is_jacobian_set() {
                 nonlinear_solver.reset_jacobian(op, &self.state.y, t);
+                self.statistics
+                    .record_linear_solver_setup(SolverState::Checkpoint);
             }
             let solve_result = nonlinear_solver.solve_in_place(
                 op,
@@ -691,6 +698,8 @@ where
                         &self.old_state.s[j],
                         t,
                     );
+                    self.statistics
+                        .record_linear_solver_setup(SolverState::Checkpoint);
                 }
 
                 // solve

--- a/diffsol/src/ode_solver/runge_kutta.rs
+++ b/diffsol/src/ode_solver/runge_kutta.rs
@@ -726,10 +726,6 @@ where
                 }
             }
         }
-        self.statistics.number_of_linear_solver_setups = op.map_or_else(
-            || s_op.as_ref().unwrap().number_of_jac_evals(),
-            |op| op.number_of_jac_evals(),
-        );
         Ok(())
     }
 

--- a/diffsol/src/ode_solver/sdirk.rs
+++ b/diffsol/src/ode_solver/sdirk.rs
@@ -20,11 +20,11 @@ use log::trace;
 use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
 
 use super::adjoint::AdjointOdeSolverMethod;
-use super::bdf::BdfStatistics;
 use super::config::SdirkConfig;
 use super::jacobian_update::SolverState;
 use super::method::AugmentedOdeSolverMethod;
 use super::sensitivities::SensitivitiesOdeSolverMethod;
+use super::OdeSolverStatistics;
 
 impl<'a, M, Eqn, LS, AugEqn> AugmentedOdeSolverMethod<'a, Eqn, AugEqn>
     for Sdirk<'a, Eqn, LS, M, AugEqn>
@@ -254,11 +254,12 @@ where
     }
 
     fn jacobian_updates(&mut self, h: Eqn::T, state: SolverState) {
-        if self.jacobian_update.check_rhs_jacobian_update(h, &state) {
-            if let Some(op) = self.op.as_mut() {
+        let did_update = if self.jacobian_update.check_rhs_jacobian_update(h, &state) {
+            let did_reset = if let Some(op) = self.op.as_mut() {
                 op.set_jacobian_is_stale();
                 self.nonlinear_solver
                     .reset_jacobian(op, &self.rk.state().y, self.rk.state().t);
+                true
             } else if let Some(s_op) = self.s_op.as_mut() {
                 s_op.set_jacobian_is_stale();
                 self.nonlinear_solver.reset_jacobian(
@@ -266,24 +267,39 @@ where
                     &self.rk.state().s[0],
                     self.rk.state().t,
                 );
-            }
+                true
+            } else {
+                false
+            };
             self.jacobian_update.update_rhs_jacobian(h);
             self.jacobian_update.update_jacobian(h);
             self.convergence.reset_eta();
+            did_reset
         } else if self.jacobian_update.check_jacobian_update(h, &state) {
             // shouldn't matter what we put in for x cause rhs_jacobian is already updated
-            if let Some(op) = self.op.as_ref() {
+            let did_reset = if let Some(op) = self.op.as_ref() {
                 self.nonlinear_solver
                     .reset_jacobian(op, &self.rk.state().y, self.rk.state().t);
+                true
             } else if let Some(s_op) = self.s_op.as_ref() {
                 self.nonlinear_solver.reset_jacobian(
                     s_op,
                     &self.rk.state().s[0],
                     self.rk.state().t,
                 );
-            }
+                true
+            } else {
+                false
+            };
             self.jacobian_update.update_jacobian(h);
             self.convergence.reset_eta();
+            did_reset
+        } else {
+            false
+        };
+
+        if did_update {
+            self.rk.statistics_mut().record_linear_solver_setup(state);
         }
     }
 
@@ -297,7 +313,7 @@ where
         }
     }
 
-    pub fn get_statistics(&self) -> &BdfStatistics {
+    pub fn get_statistics(&self) -> &OdeSolverStatistics {
         self.rk.get_statistics()
     }
 }
@@ -519,6 +535,11 @@ where
 
         self.update_op_step_size(new_h);
         self.jacobian_updates(new_h, SolverState::StepSuccess);
+        let number_of_jac_evals = self.op.as_ref().map_or_else(
+            || self.s_op.as_ref().unwrap().number_of_jac_evals(),
+            |op| op.number_of_jac_evals(),
+        );
+        self.rk.statistics_mut().number_of_linear_solver_setups = number_of_jac_evals;
         self.jacobian_update.step();
         self.rk.step_accepted(h, new_h, true)
     }
@@ -666,11 +687,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 110
         number_of_nonlinear_solver_fails: 0
-        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
         number_of_linear_solver_setups_from_first_convergence_fail: 0
         number_of_linear_solver_setups_from_second_convergence_fail: 0
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 7
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 112
@@ -691,11 +712,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 515
         number_of_nonlinear_solver_fails: 0
-        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
         number_of_linear_solver_setups_from_first_convergence_fail: 0
         number_of_linear_solver_setups_from_second_convergence_fail: 0
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 9
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 166
@@ -716,11 +737,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 66
         number_of_nonlinear_solver_fails: 0
-        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
         number_of_linear_solver_setups_from_first_convergence_fail: 0
         number_of_linear_solver_setups_from_second_convergence_fail: 0
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 5
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 68
@@ -741,11 +762,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 24
         number_of_nonlinear_solver_fails: 0
-        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
         number_of_linear_solver_setups_from_first_convergence_fail: 0
         number_of_linear_solver_setups_from_second_convergence_fail: 0
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 5
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 28
@@ -766,11 +787,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 317
         number_of_nonlinear_solver_fails: 0
-        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
         number_of_linear_solver_setups_from_first_convergence_fail: 0
         number_of_linear_solver_setups_from_second_convergence_fail: 0
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 5
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 98
@@ -848,16 +869,16 @@ mod test {
         let mut s = problem.tr_bdf2::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @"
-        number_of_linear_solver_setups: 66
+        number_of_linear_solver_setups: 67
         number_of_steps: 287
         number_of_error_test_failures: 5
         number_of_nonlinear_solver_iterations: 1610
         number_of_nonlinear_solver_fails: 8
-        number_of_linear_solver_setups_from_checkpoint: 0
-        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 8
         number_of_linear_solver_setups_from_second_convergence_fail: 0
-        number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_error_test_fail: 5
+        number_of_linear_solver_setups_from_step_success: 53
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 1613
@@ -879,11 +900,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 4146
         number_of_nonlinear_solver_fails: 30
-        number_of_linear_solver_setups_from_checkpoint: 0
-        number_of_linear_solver_setups_from_first_convergence_fail: 0
-        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 29
+        number_of_linear_solver_setups_from_second_convergence_fail: 1
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 46
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 1303
@@ -899,16 +920,16 @@ mod test {
         let mut s = problem.esdirk34::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @"
-        number_of_linear_solver_setups: 67
+        number_of_linear_solver_setups: 68
         number_of_steps: 413
         number_of_error_test_failures: 1
         number_of_nonlinear_solver_iterations: 2534
         number_of_nonlinear_solver_fails: 6
-        number_of_linear_solver_setups_from_checkpoint: 0
-        number_of_linear_solver_setups_from_first_convergence_fail: 0
-        number_of_linear_solver_setups_from_second_convergence_fail: 0
-        number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 5
+        number_of_linear_solver_setups_from_second_convergence_fail: 1
+        number_of_linear_solver_setups_from_error_test_fail: 1
+        number_of_linear_solver_setups_from_step_success: 60
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 2537
@@ -929,11 +950,11 @@ mod test {
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 6856
         number_of_nonlinear_solver_fails: 10
-        number_of_linear_solver_setups_from_checkpoint: 0
-        number_of_linear_solver_setups_from_first_convergence_fail: 0
-        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 8
+        number_of_linear_solver_setups_from_second_convergence_fail: 2
         number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_step_success: 57
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 2272
@@ -949,16 +970,16 @@ mod test {
         let mut s = problem.tr_bdf2::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
         insta::assert_yaml_snapshot!(s.get_statistics(), @"
-        number_of_linear_solver_setups: 74
+        number_of_linear_solver_setups: 75
         number_of_steps: 371
         number_of_error_test_failures: 1
         number_of_nonlinear_solver_iterations: 2622
         number_of_nonlinear_solver_fails: 5
-        number_of_linear_solver_setups_from_checkpoint: 0
-        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_checkpoint: 1
+        number_of_linear_solver_setups_from_first_convergence_fail: 5
         number_of_linear_solver_setups_from_second_convergence_fail: 0
-        number_of_linear_solver_setups_from_error_test_fail: 0
-        number_of_linear_solver_setups_from_step_success: 0
+        number_of_linear_solver_setups_from_error_test_fail: 1
+        number_of_linear_solver_setups_from_step_success: 68
         ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 2624

--- a/diffsol/src/ode_solver/sdirk.rs
+++ b/diffsol/src/ode_solver/sdirk.rs
@@ -535,11 +535,6 @@ where
 
         self.update_op_step_size(new_h);
         self.jacobian_updates(new_h, SolverState::StepSuccess);
-        let number_of_jac_evals = self.op.as_ref().map_or_else(
-            || self.s_op.as_ref().unwrap().number_of_jac_evals(),
-            |op| op.number_of_jac_evals(),
-        );
-        self.rk.statistics_mut().number_of_linear_solver_setups = number_of_jac_evals;
         self.jacobian_update.step();
         self.rk.step_accepted(h, new_h, true)
     }

--- a/diffsol/src/ode_solver/sdirk.rs
+++ b/diffsol/src/ode_solver/sdirk.rs
@@ -660,13 +660,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         let mut s = problem.tr_bdf2::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 8
         number_of_steps: 46
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 110
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 112
         number_of_jac_muls: 2
@@ -680,13 +685,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         let mut s = problem.tr_bdf2_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 10
         number_of_steps: 74
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 515
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 166
         number_of_jac_muls: 357
@@ -700,13 +710,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem::<M>(false);
         let mut s = problem.esdirk34::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 6
         number_of_steps: 18
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 66
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 68
         number_of_jac_muls: 2
@@ -720,13 +735,18 @@ mod test {
         let (problem, soln) = exponential_decay_with_algebraic_problem::<M>(false);
         let mut s = problem.esdirk34::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 6
         number_of_steps: 6
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 24
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 28
         number_of_jac_muls: 6
@@ -740,13 +760,18 @@ mod test {
         let (problem, soln) = exponential_decay_problem_sens::<M>(false);
         let mut s = problem.esdirk34_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 6
         number_of_steps: 30
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 317
         number_of_nonlinear_solver_fails: 0
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 98
         number_of_jac_muls: 225
@@ -822,13 +847,18 @@ mod test {
         let (problem, soln) = robertson::<M>(false);
         let mut s = problem.tr_bdf2::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 66
         number_of_steps: 287
         number_of_error_test_failures: 5
         number_of_nonlinear_solver_iterations: 1610
         number_of_nonlinear_solver_fails: 8
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 1613
         number_of_jac_muls: 36
@@ -843,13 +873,18 @@ mod test {
         problem.ode_options.max_nonlinear_solver_iterations = 10;
         let mut s = problem.tr_bdf2_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 77
         number_of_steps: 286
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 4146
         number_of_nonlinear_solver_fails: 30
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 1303
         number_of_jac_muls: 2954
@@ -863,13 +898,18 @@ mod test {
         let (problem, soln) = robertson::<M>(false);
         let mut s = problem.esdirk34::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 67
         number_of_steps: 413
         number_of_error_test_failures: 1
         number_of_nonlinear_solver_iterations: 2534
         number_of_nonlinear_solver_fails: 6
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 2537
         number_of_jac_muls: 39
@@ -883,13 +923,18 @@ mod test {
         let (problem, soln) = robertson_sens::<M>();
         let mut s = problem.esdirk34_sens::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, true);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 68
         number_of_steps: 333
         number_of_error_test_failures: 0
         number_of_nonlinear_solver_iterations: 6856
         number_of_nonlinear_solver_fails: 10
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 2272
         number_of_jac_muls: 4644
@@ -903,13 +948,18 @@ mod test {
         let (problem, soln) = robertson_ode::<M>(false, 1);
         let mut s = problem.tr_bdf2::<LS>().unwrap();
         test_ode_solver(&mut s, soln, None, false, false);
-        insta::assert_yaml_snapshot!(s.get_statistics(), @r###"
+        insta::assert_yaml_snapshot!(s.get_statistics(), @"
         number_of_linear_solver_setups: 74
         number_of_steps: 371
         number_of_error_test_failures: 1
         number_of_nonlinear_solver_iterations: 2622
         number_of_nonlinear_solver_fails: 5
-        "###);
+        number_of_linear_solver_setups_from_checkpoint: 0
+        number_of_linear_solver_setups_from_first_convergence_fail: 0
+        number_of_linear_solver_setups_from_second_convergence_fail: 0
+        number_of_linear_solver_setups_from_error_test_fail: 0
+        number_of_linear_solver_setups_from_step_success: 0
+        ");
         insta::assert_yaml_snapshot!(problem.eqn.rhs().statistics(), @r###"
         number_of_calls: 2624
         number_of_jac_muls: 30

--- a/diffsol/src/op/bdf.rs
+++ b/diffsol/src/op/bdf.rs
@@ -20,7 +20,6 @@ pub struct BdfCallable<Eqn: OdeEquationsImplicit> {
     rhs_jac: RefCell<Eqn::M>,
     mass_jac: RefCell<Eqn::M>,
     jacobian_is_stale: RefCell<bool>,
-    number_of_jac_evals: RefCell<usize>,
     sparsity: Option<<Eqn::M as Matrix>::Sparsity>,
 }
 
@@ -34,7 +33,6 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
             rhs_jac: RefCell::new(self.rhs_jac.borrow().clone()),
             mass_jac: RefCell::new(self.mass_jac.borrow().clone()),
             jacobian_is_stale: RefCell::new(*self.jacobian_is_stale.borrow()),
-            number_of_jac_evals: RefCell::new(*self.number_of_jac_evals.borrow()),
             sparsity: self.sparsity.clone(),
         }
     }
@@ -63,7 +61,6 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
         let c = RefCell::new(Eqn::T::zero());
         let psi_neg_y0 = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
         let jacobian_is_stale = RefCell::new(true);
-        let number_of_jac_evals = RefCell::new(0);
         let tmp = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
         let rhs_jac = RefCell::new(<Eqn::M as Matrix>::zeros(0, 0, ctx.clone()));
         let mass_jac = RefCell::new(<Eqn::M as Matrix>::zeros(0, 0, ctx.clone()));
@@ -75,7 +72,6 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
             rhs_jac,
             mass_jac,
             jacobian_is_stale,
-            number_of_jac_evals,
             tmp,
             sparsity,
         }
@@ -111,7 +107,6 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
         let c = RefCell::new(Eqn::T::zero());
         let psi_neg_y0 = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
         let jacobian_is_stale = RefCell::new(true);
-        let number_of_jac_evals = RefCell::new(0);
         let tmp = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
 
         // create the mass and rhs jacobians according to the sparsity pattern
@@ -162,7 +157,6 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
             rhs_jac,
             mass_jac,
             jacobian_is_stale,
-            number_of_jac_evals,
             tmp,
             sparsity,
         }
@@ -182,9 +176,6 @@ impl<Eqn: OdeEquationsImplicit> BdfCallable<Eqn> {
         self.tmp.borrow()
     }
 
-    pub fn number_of_jac_evals(&self) -> usize {
-        *self.number_of_jac_evals.borrow()
-    }
     pub fn set_c(&self, h: Eqn::T, alpha: Eqn::T) {
         self.c.replace(h * alpha);
     }
@@ -306,8 +297,6 @@ impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for BdfCallable<Eqn> {
             );
             y.scale_add_and_assign(mass_jac.deref(), -c, rhs_jac.deref());
         }
-        let number_of_jac_evals = *self.number_of_jac_evals.borrow() + 1;
-        self.number_of_jac_evals.replace(number_of_jac_evals);
     }
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.sparsity.clone()

--- a/diffsol/src/op/mod.rs
+++ b/diffsol/src/op/mod.rs
@@ -105,7 +105,7 @@ pub struct OpStatistics {
     pub number_of_calls: usize,
     /// number of times the jacobian-vector product was computed
     pub number_of_jac_muls: usize,
-    /// number of times the jacobian matrix was evaluated
+    /// number of times the jacobian matrix was evaluated (SUNDIALS/CVODE `nje`)
     pub number_of_matrix_evals: usize,
     /// number of times the adjoint jacobian-vector product was computed
     pub number_of_jac_adj_muls: usize,

--- a/diffsol/src/op/sdirk.rs
+++ b/diffsol/src/op/sdirk.rs
@@ -24,7 +24,6 @@ pub struct SdirkCallable<Eqn: OdeEquations> {
     rhs_jac: RefCell<Eqn::M>,
     mass_jac: RefCell<Eqn::M>,
     jacobian_is_stale: RefCell<bool>,
-    number_of_jac_evals: RefCell<usize>,
     sparsity: Option<<Eqn::M as Matrix>::Sparsity>,
 }
 
@@ -39,7 +38,6 @@ impl<Eqn: OdeEquationsImplicit> SdirkCallable<Eqn> {
             rhs_jac: RefCell::new(self.rhs_jac.borrow().clone()),
             mass_jac: RefCell::new(self.mass_jac.borrow().clone()),
             jacobian_is_stale: RefCell::new(*self.jacobian_is_stale.borrow()),
-            number_of_jac_evals: RefCell::new(*self.number_of_jac_evals.borrow()),
             sparsity: self.sparsity.clone(),
         }
     }
@@ -73,7 +71,6 @@ impl<Eqn: OdeEquationsImplicit> SdirkCallable<Eqn> {
         let ctx = eqn.context();
         let phi = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
         let jacobian_is_stale = RefCell::new(false);
-        let number_of_jac_evals = RefCell::new(0);
         let tmp = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
         let rhs_jac = RefCell::new(<Eqn::M as Matrix>::zeros(0, 0, ctx.clone()));
         let mass_jac = RefCell::new(<Eqn::M as Matrix>::zeros(0, 0, ctx.clone()));
@@ -86,7 +83,6 @@ impl<Eqn: OdeEquationsImplicit> SdirkCallable<Eqn> {
             rhs_jac,
             mass_jac,
             jacobian_is_stale,
-            number_of_jac_evals,
             tmp,
             sparsity,
         }
@@ -102,7 +98,6 @@ impl<Eqn: OdeEquationsImplicit> SdirkCallable<Eqn> {
         let h = RefCell::new(Eqn::T::zero());
         let phi = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
         let jacobian_is_stale = RefCell::new(true);
-        let number_of_jac_evals = RefCell::new(0);
         let tmp = RefCell::new(<Eqn::V as Vector>::zeros(n, ctx.clone()));
 
         // create the mass and rhs jacobians according to the sparsity pattern
@@ -155,14 +150,10 @@ impl<Eqn: OdeEquationsImplicit> SdirkCallable<Eqn> {
             mass_jac,
             sparsity,
             jacobian_is_stale,
-            number_of_jac_evals,
             tmp,
         }
     }
 
-    pub fn number_of_jac_evals(&self) -> usize {
-        *self.number_of_jac_evals.borrow()
-    }
     pub fn set_h(&self, h: Eqn::T) {
         self.h.replace(h);
     }
@@ -302,8 +293,6 @@ impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for SdirkCallable<Eqn> {
             );
             y.scale_add_and_assign(mass_jac.deref(), -(c * h), rhs_jac.deref());
         }
-        let number_of_jac_evals = *self.number_of_jac_evals.borrow() + 1;
-        self.number_of_jac_evals.replace(number_of_jac_evals);
     }
     fn jacobian_sparsity(&self) -> Option<<Self::M as Matrix>::Sparsity> {
         self.sparsity.clone()


### PR DESCRIPTION
Refactors the `BDFStatistics` into a general struct to be used by each solver. Includes the `BDFStatistics` fields plus the following additions for Jacobian/LU setups:

```rust
number_of_linear_solver_setups_from_checkpoint
number_of_linear_solver_setups_from_first_convergence_fail
number_of_linear_solver_setups_from_second_convergence_fail
number_of_linear_solver_setups_from_error_test_fail
number_of_linear_solver_setups_from_step_success
```