### PR TITLE
Decouple integrated sensitivity columns from `nparams`

### DIFF
--- a/crates/diffsol/src/ode_equations/sens_equations.rs
+++ b/crates/diffsol/src/ode_equations/sens_equations.rs
@@ -246,15 +246,15 @@ where
 {
     pub(crate) fn new(problem: &'a OdeSolverProblem<Eqn>) -> Self {
         let eqn = &problem.eqn;
-        // `nsens` cannot change after construction, so check the contract once here.
-        let rhs = eqn.rhs();
-        let (nsens, nparams) = (rhs.nsens(), rhs.nparams());
+        // the state sizes itself from `nsens` once, so validate the mapping here rather than per step
+        let eqn_rhs = eqn.rhs();
+        let (nsens, nparams) = (eqn_rhs.nsens(), eqn_rhs.nparams());
         assert!(
             nsens <= nparams,
             "Op::nsens() must be <= Op::nparams(), got {nsens} > {nparams}"
         );
         for sens_col in 0..nsens {
-            let param_index = rhs.sens_param_index(sens_col);
+            let param_index = eqn_rhs.sens_param_index(sens_col);
             assert!(
                 param_index < nparams,
                 "Op::sens_param_index({sens_col}) must be < Op::nparams(), \
@@ -367,7 +367,7 @@ impl<Eqn: OdeEquationsImplicitSens> AugmentedOdeEquations<Eqn> for SensEquations
         self.rhs.update_state(y, dy, t);
     }
     fn set_index(&mut self, index: usize) {
-        // `index` is a sensitivity column; both ops want a parameter index.
+        // `index` is a sensitivity column, but both ops want a parameter index
         let param_index = self.eqn.rhs().sens_param_index(index);
         self.rhs.set_param_index(param_index);
         self.init.set_param_index(param_index);
@@ -522,9 +522,7 @@ mod tests {
         assert_eq!(sens.get_index(2, 2), 0.0);
     }
 
-    /// Rhs wrapper overriding the integrated column set and the column -> parameter
-    /// mapping, delegating everything else, so a test can decouple them from `nparams`.
-    /// One column is integrated per entry of `sens_params`.
+    /// Rhs wrapper that delegates everything but `nsens`/`sens_param_index`, integrating one column per entry of `sens_params`.
     struct SensOverrideRhs<'a, Eqn: OdeEquations> {
         inner: <Eqn as OdeEquationsRef<'a>>::Rhs,
         sens_params: Vec<usize>,
@@ -573,9 +571,7 @@ mod tests {
         }
     }
 
-    /// Equations wrapper that swaps in [`SensOverrideRhs`] for the rhs op. Note that the
-    /// override has to live on the rhs: this struct's own [`Op`] impl is never consulted
-    /// for `nsens`, so it forwards `nparams` unchanged.
+    /// Equations wrapper that swaps in [`SensOverrideRhs`] for the rhs op; its own [`Op`] impl forwards `nparams` unchanged, as `nsens` is only read off the rhs.
     struct SensOverrideEqn<Eqn> {
         inner: Eqn,
         sens_params: Vec<usize>,
@@ -639,8 +635,7 @@ mod tests {
         }
     }
 
-    /// Rebuild `problem` around a [`SensOverrideEqn`] integrating one sensitivity column
-    /// per entry of `sens_params`, keeping every tolerance.
+    /// Rebuild `problem` around a [`SensOverrideEqn`] over `sens_params`, keeping every tolerance.
     fn with_sens_override<Eqn: OdeEquationsImplicitSens>(
         problem: OdeSolverProblem<Eqn>,
         sens_params: Vec<usize>,
@@ -676,8 +671,7 @@ mod tests {
         assert_eq!(sens_eqn.max_index(), 1);
     }
 
-    /// Checked at construction, so it fires in release too rather than as an opaque
-    /// out-of-bounds panic mid-solve.
+    /// Test that `nsens() > nparams()` is rejected at construction, rather than as an opaque out-of-bounds panic mid-solve.
     #[test]
     #[should_panic(expected = "Op::nsens() must be <= Op::nparams(), got 5 > 3")]
     fn sens_equations_new_rejects_nsens_above_nparams() {
@@ -686,7 +680,7 @@ mod tests {
         let _ = SensEquations::new(&wrapped_problem);
     }
 
-    /// Likewise for an out-of-range column -> parameter mapping.
+    /// Test that an out-of-range column -> parameter mapping is likewise rejected at construction.
     #[test]
     #[should_panic(expected = "Op::sens_param_index(0) must be < Op::nparams(), got 7 >= 3")]
     fn sens_equations_new_rejects_out_of_range_sens_param_index() {
@@ -695,8 +689,7 @@ mod tests {
         let _ = SensEquations::new(&wrapped_problem);
     }
 
-    /// Solve for state and sensitivities at `t_eval`, through BDF or Tsit45. Generic over
-    /// the equations so wrapped and unwrapped problems share one call site.
+    /// Solve for state and sensitivities at `t_eval` through BDF or Tsit45, generic over the equations so wrapped and unwrapped problems share a call site.
     fn solve_dense_sens<Eqn>(
         problem: OdeSolverProblem<Eqn>,
         t_eval: &[f64],
@@ -723,9 +716,7 @@ mod tests {
 
     const SENS_T_EVAL: [f64; 3] = [1e-4, 1e-2, 1.0];
 
-    /// Solve `robertson_sens`, optionally wrapped to integrate only `sens_params`. Returns
-    /// the state, the sensitivity columns at [`SENS_T_EVAL`], and the tolerances for
-    /// comparing solves.
+    /// Solve `robertson_sens`, optionally wrapped to integrate only `sens_params`, returning the state, the sensitivity columns, and the tolerances for comparing solves.
     fn solve_robertson_sens(sens_params: Option<Vec<usize>>) -> (Mcpu, Vec<Mcpu>, Vcpu, f64) {
         let (problem, _soln) = robertson_sens::<Mcpu>();
         let (atol, rtol) = (problem.atol.clone(), problem.rtol);
@@ -736,8 +727,7 @@ mod tests {
         (y, sens, atol, rtol)
     }
 
-    /// With `nsens == nparams` and an identity mapping the override plumbing must reproduce
-    /// the unwrapped solve bit-for-bit, so the default path is provably untouched.
+    /// Test that an identity mapping over every parameter reproduces the unwrapped solve bit-for-bit, i.e. the default path is untouched.
     #[test]
     fn solve_dense_sensitivities_bit_identical_when_nsens_equals_nparams() {
         let (y_full, sens_full, _, _) = solve_robertson_sens(None);
@@ -751,9 +741,8 @@ mod tests {
         );
     }
 
-    /// A non-identity mapping must integrate the selected parameter, not the one sharing
-    /// the column index. Robertson's parameters span orders of magnitude (0.04, 1e4, 3e7),
-    /// so a mix-up is unmissable.
+    /// Test that a non-identity mapping integrates the selected parameter, not the one sharing the column index.
+    /// Robertson's parameters span orders of magnitude (0.04, 1e4, 3e7), so a mix-up cannot pass.
     #[test]
     fn solve_dense_sensitivities_respects_sens_param_index_mapping() {
         let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
@@ -770,9 +759,8 @@ mod tests {
         }
     }
 
-    /// A reduced `nsens` must integrate fewer columns while the leading column still
-    /// tracks the full solve. Only to solver tolerance, not bit-exact: fewer columns shifts
-    /// the step sequence, so both solves are valid to the requested accuracy.
+    /// Test that a reduced `nsens` integrates fewer columns while the leading one still tracks the full solve.
+    /// Agreement is to solver tolerance rather than bit-exact, as dropping columns shifts the step sequence.
     #[test]
     fn solve_dense_sensitivities_respects_nsens_override() {
         let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
@@ -786,7 +774,6 @@ mod tests {
         assert_eq!(sens_reduced[0].ncols(), SENS_T_EVAL.len());
         assert_eq!(sens_reduced[0].nrows(), sens_full[0].nrows());
 
-        // Compare under the solver's own weighted norm, as other solve tests do.
         for j in 0..SENS_T_EVAL.len() {
             sens_reduced[0].column(j).into_owned().assert_eq_norm(
                 &sens_full[0].column(j).into_owned(),
@@ -798,9 +785,8 @@ mod tests {
     }
 
     /// `dx/dt = -p[0]·x`, `x(0) = 1`, with a reset `x -> x + p[1]` firing at `x = 0.5`.
-    /// Parameter 1 enters the problem only through the reset, so its post-event
-    /// sensitivity comes entirely from the parameter-space seed in the reset correction:
-    /// s_1(t) = exp(-p[0]·(t - t_root)) for t > t_root = ln(2)/p[0], and 0 before.
+    /// p[1] enters only through the reset, so its sensitivity comes entirely from the parameter-space seed in the reset correction:
+    /// s_1 = 0 up to t_root = ln(2)/p[0], then exp(-p[0]·(t - t_root)) until the root fires again at t_root + ln(1.6)/p[0] ≈ 1.16.
     fn decay_with_param_dependent_reset_problem() -> OdeSolverProblem<
         impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
     > {
@@ -829,7 +815,7 @@ mod tests {
             .reset_sens_implicit(
                 |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = x[0] + p[1],
                 |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[0],
-                // dreset/dp · v = v[1]: reads the parameter-space seed at parameter 1.
+                // dreset/dp · v = v[1], i.e. reads the seed at parameter 1
                 |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[1],
             )
             .build()
@@ -838,8 +824,7 @@ mod tests {
 
     const RESET_SENS_T_EVAL: [f64; 3] = [0.2, 1.0, 1.5];
 
-    /// Solve [`decay_with_param_dependent_reset_problem`], optionally with only
-    /// parameter 1's sensitivity integrated (column 0 -> parameter 1).
+    /// Solve [`decay_with_param_dependent_reset_problem`], optionally with only parameter 1's sensitivity integrated (column 0 -> parameter 1).
     fn solve_decay_reset_sens(use_bdf: bool, mapped: bool) -> (Vec<Mcpu>, Vcpu, f64) {
         let problem = decay_with_param_dependent_reset_problem();
         let (atol, rtol) = (problem.atol.clone(), problem.rtol);
@@ -860,8 +845,7 @@ mod tests {
         let (sens_full, atol, rtol) = solve_decay_reset_sens(use_bdf, false);
         let (sens_mapped, _, _) = solve_decay_reset_sens(use_bdf, true);
 
-        // Guard: parameter 1's sensitivity is nonzero after the event (s_1 = 2/e at
-        // t = 1), so the comparison below cannot pass vacuously.
+        // guard: s_1(1.0) = 2/e is nonzero, so the comparison below cannot pass vacuously
         let expected = 2.0 / std::f64::consts::E;
         assert!(
             (sens_full[1].get_index(0, 1) - expected).abs() < 1e-3,
@@ -880,22 +864,19 @@ mod tests {
         }
     }
 
-    /// The reset correction seeds parameter space per column; it must seed
-    /// `sens_param_index(j)`, not column `j`. Tsit45 routes through
-    /// `apply_reset_with_sens`.
+    /// Test that the reset correction seeds `sens_param_index(j)` and not column `j`, via Tsit45's `apply_reset_with_sens`.
     #[test]
     fn reset_sens_correction_respects_mapping_tsit45() {
         assert_reset_sens_correction_respects_mapping(false);
     }
 
-    /// As above through BDF, which routes through `apply_reset_with_sens_mass`.
+    /// As above, via BDF's `apply_reset_with_sens_mass`.
     #[test]
     fn reset_sens_correction_respects_mapping_bdf() {
         assert_reset_sens_correction_respects_mapping(true);
     }
 
-    /// `nsens() == 0` is the degenerate end of the documented range: nothing to integrate,
-    /// while the main equation (reset and all) still solves.
+    /// Test that `nsens() == 0` integrates no columns while the main equation, resets and all, still solves.
     #[test]
     fn solve_dense_sensitivities_with_no_columns() {
         for use_bdf in [true, false] {
@@ -907,9 +888,8 @@ mod tests {
         }
     }
 
-    /// `dx/dt = -p[0]·x`, `x(0) = 1`, output `g = x + p[1]`, root at `x = 0.5` and no
-    /// reset. Parameter 1 enters only through the output, so `dg/dp[1] = 1` exactly and
-    /// the out-sensitivity seed is the only thing that can produce it.
+    /// `dx/dt = -p[0]·x`, `x(0) = 1`, output `g = x + p[1]`, root at `x = 0.5` and no reset.
+    /// p[1] enters only through the output, so `dg/dp[1] = 1` exactly and only the out-sensitivity seed can produce it.
     fn decay_with_out_problem() -> OdeSolverProblem<
         impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
     > {
@@ -938,7 +918,7 @@ mod tests {
             .out_sens_implicit(
                 |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = x[0] + p[1],
                 |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[0],
-                // dg/dp · v = v[1]: reads the parameter-space seed at parameter 1.
+                // dg/dp · v = v[1], i.e. reads the seed at parameter 1
                 |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[1],
                 1,
             )
@@ -946,13 +926,10 @@ mod tests {
             .unwrap()
     }
 
-    /// The root at `x = 0.5` fires at `t = ln(2)`, between the second and third entry, so
-    /// the final column is written by `write_state_sens_out` rather than by the
-    /// interpolating path.
+    /// The root at `x = 0.5` fires at `t = ln(2)`, between the last two entries, so the final column comes from `write_state_sens_out` rather than the interpolating path.
     const OUT_SENS_T_EVAL: [f64; 3] = [0.2, 0.5, 1.0];
 
-    /// Both out-sensitivity seed sites are parameter-space: they must seed
-    /// `sens_param_index(j)`, not column `j`.
+    /// Test that both out-sensitivity seed sites seed `sens_param_index(j)` and not column `j`.
     #[test]
     fn out_sens_respects_mapping() {
         let (y_full, sens_full) =
@@ -963,8 +940,7 @@ mod tests {
             true,
         );
 
-        // The last column is the root time, so g = 0.5 + p[1]; confirms the solve stopped
-        // on the root and the `write_state_sens_out` path ran.
+        // g = 0.5 + p[1] at the root time confirms the `write_state_sens_out` path ran
         assert_eq!(y_full.ncols(), OUT_SENS_T_EVAL.len());
         assert!(
             (y_full.get_index(0, 2) - 0.8).abs() < 1e-5,
@@ -972,8 +948,7 @@ mod tests {
             y_full.get_index(0, 2)
         );
 
-        // Guard: dg/dp[0] = -t·exp(-t) is nowhere near dg/dp[1] = 1, so seeding the wrong
-        // index cannot pass. A wrong seed gives 0 for the mapped column.
+        // guard: dg/dp[0] = -t·exp(-t) is nowhere near dg/dp[1] = 1, so a wrong seed cannot pass
         assert_eq!(sens_full.len(), 2);
         let expected_p0 = -0.2 * (-0.2f64).exp();
         assert!(

--- a/crates/diffsol/src/ode_equations/sens_equations.rs
+++ b/crates/diffsol/src/ode_equations/sens_equations.rs
@@ -673,20 +673,18 @@ mod tests {
 
     /// Test that `nsens() > nparams()` is rejected at construction, rather than as an opaque out-of-bounds panic mid-solve.
     #[test]
-    #[should_panic(expected = "Op::nsens() must be <= Op::nparams(), got 5 > 3")]
+    #[should_panic(expected = "Op::nsens() must be <= Op::nparams(), got 3 > 2")]
     fn sens_equations_new_rejects_nsens_above_nparams() {
-        let (problem, _soln) = robertson_sens::<Mcpu>();
-        let wrapped_problem = with_sens_override(problem, vec![0, 1, 2, 0, 1]);
-        let _ = SensEquations::new(&wrapped_problem);
+        let problem = decay_with_param_dependent_reset_problem(Some(vec![0, 1, 0]));
+        let _ = SensEquations::new(&problem);
     }
 
     /// Test that an out-of-range column -> parameter mapping is likewise rejected at construction.
     #[test]
-    #[should_panic(expected = "Op::sens_param_index(0) must be < Op::nparams(), got 7 >= 3")]
+    #[should_panic(expected = "Op::sens_param_index(0) must be < Op::nparams(), got 7 >= 2")]
     fn sens_equations_new_rejects_out_of_range_sens_param_index() {
-        let (problem, _soln) = robertson_sens::<Mcpu>();
-        let wrapped_problem = with_sens_override(problem, vec![7]);
-        let _ = SensEquations::new(&wrapped_problem);
+        let problem = decay_with_param_dependent_reset_problem(Some(vec![7]));
+        let _ = SensEquations::new(&problem);
     }
 
     /// Solve for state and sensitivities at `t_eval` through BDF or Tsit45, generic over the equations so wrapped and unwrapped problems share a call site.
@@ -741,14 +739,17 @@ mod tests {
         );
     }
 
-    /// Test that a non-identity mapping integrates the selected parameter, not the one sharing the column index.
+    /// Test that a reduced `nsens` integrates only the mapped parameter, not the one sharing the column index.
     /// Robertson's parameters span orders of magnitude (0.04, 1e4, 3e7), so a mix-up cannot pass.
+    /// Agreement is to solver tolerance rather than bit-exact, as dropping columns shifts the step sequence.
     #[test]
-    fn solve_dense_sensitivities_respects_sens_param_index_mapping() {
+    fn solve_dense_sensitivities_respects_nsens_and_mapping() {
         let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
         let (_, sens_mapped, _, _) = solve_robertson_sens(Some(vec![2]));
 
         assert_eq!(sens_mapped.len(), 1, "one column was selected");
+        assert_eq!(sens_mapped[0].ncols(), SENS_T_EVAL.len());
+        assert_eq!(sens_mapped[0].nrows(), sens_full[2].nrows());
         for j in 0..SENS_T_EVAL.len() {
             sens_mapped[0].column(j).into_owned().assert_eq_norm(
                 &sens_full[2].column(j).into_owned(),
@@ -759,43 +760,24 @@ mod tests {
         }
     }
 
-    /// Test that a reduced `nsens` integrates fewer columns while the leading one still tracks the full solve.
-    /// Agreement is to solver tolerance rather than bit-exact, as dropping columns shifts the step sequence.
-    #[test]
-    fn solve_dense_sensitivities_respects_nsens_override() {
-        let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
-        let (_, sens_reduced, _, _) = solve_robertson_sens(Some(vec![0]));
-
-        assert_eq!(
-            sens_reduced.len(),
-            1,
-            "only the leading sensitivity column should be integrated"
-        );
-        assert_eq!(sens_reduced[0].ncols(), SENS_T_EVAL.len());
-        assert_eq!(sens_reduced[0].nrows(), sens_full[0].nrows());
-
-        for j in 0..SENS_T_EVAL.len() {
-            sens_reduced[0].column(j).into_owned().assert_eq_norm(
-                &sens_full[0].column(j).into_owned(),
-                &atol,
-                rtol,
-                10.0,
-            );
-        }
-    }
-
     /// `dx/dt = -p[0]·x`, `x(0) = 1`, with a reset `x -> x + p[1]` firing at `x = 0.5`.
     /// p[1] enters only through the reset, so its sensitivity comes entirely from the parameter-space seed in the reset correction:
     /// s_1 = 0 up to t_root = ln(2)/p[0], then exp(-p[0]·(t - t_root)) until the root fires again at t_root + ln(1.6)/p[0] ≈ 1.16.
-    fn decay_with_param_dependent_reset_problem() -> OdeSolverProblem<
+    fn decay_with_param_dependent_reset_problem(
+        sens_params: Option<Vec<usize>>,
+    ) -> OdeSolverProblem<
         impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
     > {
-        OdeBuilder::<Mcpu>::new()
+        let mut builder = OdeBuilder::<Mcpu>::new()
             .p([1.0, 0.3])
             .rtol(1e-6)
             .atol([1e-6])
             .sens_rtol(1e-6)
-            .sens_atol([1e-6])
+            .sens_atol([1e-6]);
+        if let Some(sens_params) = sens_params {
+            builder = builder.sens_params(sens_params);
+        }
+        builder
             .rhs_sens_implicit(
                 |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = -p[0] * x[0],
                 |_x: &Vcpu, p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = -p[0] * v[0],
@@ -824,26 +806,20 @@ mod tests {
 
     const RESET_SENS_T_EVAL: [f64; 3] = [0.2, 1.0, 1.5];
 
-    /// Solve [`decay_with_param_dependent_reset_problem`], optionally with only parameter 1's sensitivity integrated (column 0 -> parameter 1).
-    fn solve_decay_reset_sens(use_bdf: bool, mapped: bool) -> (Vec<Mcpu>, Vcpu, f64) {
-        let problem = decay_with_param_dependent_reset_problem();
+    /// Solve [`decay_with_param_dependent_reset_problem`], returning the sensitivity columns and the tolerances for comparing solves.
+    fn solve_decay_reset_sens(
+        use_bdf: bool,
+        sens_params: Option<Vec<usize>>,
+    ) -> (Vec<Mcpu>, Vcpu, f64) {
+        let problem = decay_with_param_dependent_reset_problem(sens_params);
         let (atol, rtol) = (problem.atol.clone(), problem.rtol);
-        let sens = if mapped {
-            solve_dense_sens(
-                with_sens_override(problem, vec![1]),
-                &RESET_SENS_T_EVAL,
-                use_bdf,
-            )
-            .1
-        } else {
-            solve_dense_sens(problem, &RESET_SENS_T_EVAL, use_bdf).1
-        };
+        let sens = solve_dense_sens(problem, &RESET_SENS_T_EVAL, use_bdf).1;
         (sens, atol, rtol)
     }
 
     fn assert_reset_sens_correction_respects_mapping(use_bdf: bool) {
-        let (sens_full, atol, rtol) = solve_decay_reset_sens(use_bdf, false);
-        let (sens_mapped, _, _) = solve_decay_reset_sens(use_bdf, true);
+        let (sens_full, atol, rtol) = solve_decay_reset_sens(use_bdf, None);
+        let (sens_mapped, _, _) = solve_decay_reset_sens(use_bdf, Some(vec![1]));
 
         // guard: s_1(1.0) = 2/e is nonzero, so the comparison below cannot pass vacuously
         let expected = 2.0 / std::f64::consts::E;
@@ -880,7 +856,7 @@ mod tests {
     #[test]
     fn solve_dense_sensitivities_with_no_columns() {
         for use_bdf in [true, false] {
-            let problem = with_sens_override(decay_with_param_dependent_reset_problem(), vec![]);
+            let problem = decay_with_param_dependent_reset_problem(Some(vec![]));
             let (y, sens) = solve_dense_sens(problem, &RESET_SENS_T_EVAL, use_bdf);
             assert!(sens.is_empty());
             assert_eq!(y.ncols(), RESET_SENS_T_EVAL.len());
@@ -890,15 +866,21 @@ mod tests {
 
     /// `dx/dt = -p[0]·x`, `x(0) = 1`, output `g = x + p[1]`, root at `x = 0.5` and no reset.
     /// p[1] enters only through the output, so `dg/dp[1] = 1` exactly and only the out-sensitivity seed can produce it.
-    fn decay_with_out_problem() -> OdeSolverProblem<
+    fn decay_with_out_problem(
+        sens_params: Option<Vec<usize>>,
+    ) -> OdeSolverProblem<
         impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
     > {
-        OdeBuilder::<Mcpu>::new()
+        let mut builder = OdeBuilder::<Mcpu>::new()
             .p([1.0, 0.3])
             .rtol(1e-6)
             .atol([1e-6])
             .sens_rtol(1e-6)
-            .sens_atol([1e-6])
+            .sens_atol([1e-6]);
+        if let Some(sens_params) = sens_params {
+            builder = builder.sens_params(sens_params);
+        }
+        builder
             .rhs_sens_implicit(
                 |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = -p[0] * x[0],
                 |_x: &Vcpu, p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = -p[0] * v[0],
@@ -933,9 +915,9 @@ mod tests {
     #[test]
     fn out_sens_respects_mapping() {
         let (y_full, sens_full) =
-            solve_dense_sens(decay_with_out_problem(), &OUT_SENS_T_EVAL, true);
+            solve_dense_sens(decay_with_out_problem(None), &OUT_SENS_T_EVAL, true);
         let (_, sens_mapped) = solve_dense_sens(
-            with_sens_override(decay_with_out_problem(), vec![1]),
+            decay_with_out_problem(Some(vec![1])),
             &OUT_SENS_T_EVAL,
             true,
         );

--- a/crates/diffsol/src/ode_equations/sens_equations.rs
+++ b/crates/diffsol/src/ode_equations/sens_equations.rs
@@ -246,6 +246,20 @@ where
 {
     pub(crate) fn new(problem: &'a OdeSolverProblem<Eqn>) -> Self {
         let eqn = &problem.eqn;
+        // `n_sens` cannot change after construction, so check the contract once here.
+        let (n_sens, nparams) = (eqn.rhs().n_sens(), eqn.rhs().nparams());
+        assert!(
+            n_sens <= nparams,
+            "Op::n_sens() must be <= Op::nparams(), got {n_sens} > {nparams}"
+        );
+        for sens_col in 0..n_sens {
+            let param_index = eqn.rhs().sens_param_index(sens_col);
+            assert!(
+                param_index < nparams,
+                "Op::sens_param_index({sens_col}) must be < Op::nparams(), \
+                 got {param_index} >= {nparams}"
+            );
+        }
         let rtol = problem.sens_rtol;
         let atol = problem.sens_atol.as_ref();
         let rhs = SensRhs::new(eqn, true);
@@ -346,14 +360,16 @@ impl<Eqn: OdeEquationsImplicitSens> AugmentedOdeEquations<Eqn> for SensEquations
     }
 
     fn max_index(&self) -> usize {
-        self.nparams()
+        self.eqn.rhs().n_sens()
     }
     fn update_rhs_out_state(&mut self, y: &Eqn::V, dy: &Eqn::V, t: Eqn::T) {
         self.rhs.update_state(y, dy, t);
     }
     fn set_index(&mut self, index: usize) {
-        self.rhs.set_param_index(index);
-        self.init.set_param_index(index);
+        // `index` is a sensitivity column; both ops want a parameter index.
+        let param_index = self.eqn.rhs().sens_param_index(index);
+        self.rhs.set_param_index(param_index);
+        self.init.set_param_index(param_index);
     }
     fn integrate_main_eqn(&self) -> bool {
         true
@@ -369,8 +385,10 @@ mod tests {
             exponential_decay_with_algebraic::exponential_decay_with_algebraic_problem_sens,
             robertson::robertson_sens,
         },
-        AugmentedOdeEquations, DenseMatrix, MatrixCommon, NalgebraVec, NonLinearOp, RkState,
-        SensEquations, Vector,
+        AugmentedOdeEquations, DenseMatrix, MatrixCommon, NalgebraVec, NonLinearOp,
+        NonLinearOpJacobian, NonLinearOpSens, OdeEquations, OdeEquationsImplicit,
+        OdeEquationsImplicitSens, OdeEquationsRef, OdeSolverProblem, Op, RkState, SensEquations,
+        Vector, VectorView,
     };
     type Mcpu = NalgebraMat<f64>;
     type Vcpu = NalgebraVec<f64>;
@@ -501,5 +519,421 @@ mod tests {
         assert_eq!(sens.get_index(2, 0), 0.0);
         assert_eq!(sens.get_index(2, 1), 0.0);
         assert_eq!(sens.get_index(2, 2), 0.0);
+    }
+
+    /// Rhs wrapper overriding `n_sens` and the column -> parameter mapping, delegating
+    /// everything else, so a test can decouple them from `nparams`.
+    struct NSensOverrideRhs<'a, Eqn: OdeEquations> {
+        inner: <Eqn as OdeEquationsRef<'a>>::Rhs,
+        n_sens: usize,
+        sens_params: Option<Vec<usize>>,
+    }
+
+    impl<Eqn: OdeEquations> Op for NSensOverrideRhs<'_, Eqn> {
+        type T = Eqn::T;
+        type V = Eqn::V;
+        type M = Eqn::M;
+        type C = Eqn::C;
+        fn nstates(&self) -> usize {
+            self.inner.nstates()
+        }
+        fn nout(&self) -> usize {
+            self.inner.nout()
+        }
+        fn nparams(&self) -> usize {
+            self.inner.nparams()
+        }
+        fn context(&self) -> &Self::C {
+            self.inner.context()
+        }
+        fn n_sens(&self) -> usize {
+            self.n_sens
+        }
+        fn sens_param_index(&self, sens_col: usize) -> usize {
+            match &self.sens_params {
+                Some(map) => map[sens_col],
+                None => sens_col,
+            }
+        }
+    }
+
+    impl<Eqn: OdeEquations> NonLinearOp for NSensOverrideRhs<'_, Eqn> {
+        fn call_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::V) {
+            self.inner.call_inplace(x, t, y)
+        }
+    }
+
+    impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for NSensOverrideRhs<'_, Eqn> {
+        fn jac_mul_inplace(&self, x: &Self::V, t: Self::T, v: &Self::V, y: &mut Self::V) {
+            self.inner.jac_mul_inplace(x, t, v, y)
+        }
+    }
+
+    impl<Eqn: OdeEquationsImplicitSens> NonLinearOpSens for NSensOverrideRhs<'_, Eqn> {
+        fn sens_mul_inplace(&self, x: &Self::V, t: Self::T, v: &Self::V, y: &mut Self::V) {
+            self.inner.sens_mul_inplace(x, t, v, y)
+        }
+    }
+
+    /// Equations wrapper that swaps in [`NSensOverrideRhs`] for the rhs op.
+    struct NSensOverrideEqn<Eqn> {
+        inner: Eqn,
+        n_sens: usize,
+        sens_params: Option<Vec<usize>>,
+    }
+
+    impl<Eqn: OdeEquations> Op for NSensOverrideEqn<Eqn> {
+        type T = Eqn::T;
+        type V = Eqn::V;
+        type M = Eqn::M;
+        type C = Eqn::C;
+        fn nstates(&self) -> usize {
+            self.inner.nstates()
+        }
+        fn nout(&self) -> usize {
+            self.inner.nout()
+        }
+        fn nparams(&self) -> usize {
+            self.inner.nparams()
+        }
+        fn context(&self) -> &Self::C {
+            self.inner.context()
+        }
+    }
+
+    impl<'a, Eqn: OdeEquationsImplicitSens> OdeEquationsRef<'a> for NSensOverrideEqn<Eqn> {
+        type Mass = <Eqn as OdeEquationsRef<'a>>::Mass;
+        type Rhs = NSensOverrideRhs<'a, Eqn>;
+        type Root = <Eqn as OdeEquationsRef<'a>>::Root;
+        type Init = <Eqn as OdeEquationsRef<'a>>::Init;
+        type Out = <Eqn as OdeEquationsRef<'a>>::Out;
+        type Reset = <Eqn as OdeEquationsRef<'a>>::Reset;
+    }
+
+    impl<Eqn: OdeEquationsImplicitSens> OdeEquations for NSensOverrideEqn<Eqn> {
+        fn rhs(&self) -> <Self as OdeEquationsRef<'_>>::Rhs {
+            NSensOverrideRhs {
+                inner: self.inner.rhs(),
+                n_sens: self.n_sens,
+                sens_params: self.sens_params.clone(),
+            }
+        }
+        fn mass(&self) -> Option<<Self as OdeEquationsRef<'_>>::Mass> {
+            self.inner.mass()
+        }
+        fn root(&self) -> Option<<Self as OdeEquationsRef<'_>>::Root> {
+            self.inner.root()
+        }
+        fn out(&self) -> Option<<Self as OdeEquationsRef<'_>>::Out> {
+            self.inner.out()
+        }
+        fn reset(&self) -> Option<<Self as OdeEquationsRef<'_>>::Reset> {
+            self.inner.reset()
+        }
+        fn init(&self) -> <Self as OdeEquationsRef<'_>>::Init {
+            self.inner.init()
+        }
+        fn set_params(&mut self, p: &Self::V) {
+            self.inner.set_params(p)
+        }
+        fn get_params(&self, p: &mut Self::V) {
+            self.inner.get_params(p)
+        }
+    }
+
+    /// Rebuild `problem` around an [`NSensOverrideEqn`], keeping every tolerance.
+    fn with_n_sens_override<Eqn: OdeEquationsImplicitSens>(
+        problem: OdeSolverProblem<Eqn>,
+        n_sens: usize,
+    ) -> OdeSolverProblem<NSensOverrideEqn<Eqn>> {
+        with_sens_override(problem, n_sens, None)
+    }
+
+    /// As [`with_n_sens_override`], but also installing a column -> parameter mapping.
+    fn with_sens_override<Eqn: OdeEquationsImplicitSens>(
+        problem: OdeSolverProblem<Eqn>,
+        n_sens: usize,
+        sens_params: Option<Vec<usize>>,
+    ) -> OdeSolverProblem<NSensOverrideEqn<Eqn>> {
+        OdeSolverProblem::new(
+            NSensOverrideEqn {
+                inner: problem.eqn,
+                n_sens,
+                sens_params,
+            },
+            problem.rtol,
+            problem.atol,
+            problem.sens_rtol,
+            problem.sens_atol,
+            problem.out_rtol,
+            problem.out_atol,
+            problem.param_rtol,
+            problem.param_atol,
+            problem.t0,
+            problem.h0,
+            problem.integrate_out,
+            problem.ic_options,
+            problem.ode_options,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn max_index_respects_n_sens_override() {
+        let (problem, _soln) = robertson_sens::<Mcpu>();
+        let wrapped_problem = with_n_sens_override(problem, 1);
+        let sens_eqn = SensEquations::new(&wrapped_problem);
+        assert_eq!(sens_eqn.nparams(), 3);
+        assert_eq!(sens_eqn.max_index(), 1);
+    }
+
+    /// Checked at construction, so it fires in release too rather than as an opaque
+    /// out-of-bounds panic mid-solve.
+    #[test]
+    #[should_panic(expected = "Op::n_sens() must be <= Op::nparams(), got 5 > 3")]
+    fn sens_equations_new_rejects_n_sens_above_nparams() {
+        let (problem, _soln) = robertson_sens::<Mcpu>();
+        let wrapped_problem = with_n_sens_override(problem, 5);
+        let _ = SensEquations::new(&wrapped_problem);
+    }
+
+    /// Likewise for an out-of-range column -> parameter mapping.
+    #[test]
+    #[should_panic(expected = "Op::sens_param_index(0) must be < Op::nparams(), got 7 >= 3")]
+    fn sens_equations_new_rejects_out_of_range_sens_param_index() {
+        let (problem, _soln) = robertson_sens::<Mcpu>();
+        let wrapped_problem = with_sens_override(problem, 1, Some(vec![7]));
+        let _ = SensEquations::new(&wrapped_problem);
+    }
+
+    const SENS_T_EVAL: [f64; 3] = [1e-4, 1e-2, 1.0];
+
+    /// Solve `robertson_sens`, optionally with a reduced `n_sens`. Returns the state, the
+    /// sensitivity columns at [`SENS_T_EVAL`], and the tolerances for comparing solves.
+    fn solve_robertson_sens(n_sens_override: Option<usize>) -> (Mcpu, Vec<Mcpu>, Vcpu, f64) {
+        solve_robertson_sens_mapped(n_sens_override, None)
+    }
+
+    /// As [`solve_robertson_sens`], but able to install a column -> parameter mapping.
+    fn solve_robertson_sens_mapped(
+        n_sens_override: Option<usize>,
+        sens_params: Option<Vec<usize>>,
+    ) -> (Mcpu, Vec<Mcpu>, Vcpu, f64) {
+        use crate::{NalgebraLU, SensitivitiesOdeSolverMethod};
+        let (problem, _soln) = robertson_sens::<Mcpu>();
+        let (atol, rtol) = (problem.atol.clone(), problem.rtol);
+        let (y, sens) = match n_sens_override {
+            None => {
+                let (y, sens, _) = problem
+                    .bdf_sens::<NalgebraLU<f64>>()
+                    .unwrap()
+                    .solve_dense_sensitivities(&SENS_T_EVAL)
+                    .unwrap();
+                (y, sens)
+            }
+            Some(n_sens) => {
+                let wrapped = with_sens_override(problem, n_sens, sens_params);
+                let (y, sens, _) = wrapped
+                    .bdf_sens::<NalgebraLU<f64>>()
+                    .unwrap()
+                    .solve_dense_sensitivities(&SENS_T_EVAL)
+                    .unwrap();
+                (y, sens)
+            }
+        };
+        (y, sens, atol, rtol)
+    }
+
+    /// With `n_sens == nparams` the override plumbing must reproduce the unwrapped solve
+    /// bit-for-bit, so the default path is provably untouched.
+    #[test]
+    fn solve_dense_sensitivities_bit_identical_when_n_sens_equals_nparams() {
+        let (y_full, sens_full, _, _) = solve_robertson_sens(None);
+        let (y_wrapped, sens_wrapped, _, _) = solve_robertson_sens(Some(3));
+
+        assert_eq!(sens_full.len(), 3, "robertson_sens has 3 parameters");
+        assert_eq!(y_full, y_wrapped, "state trajectory must be bit-identical");
+        assert_eq!(
+            sens_full, sens_wrapped,
+            "sens columns must be bit-identical"
+        );
+    }
+
+    /// A non-identity mapping must integrate the selected parameter, not the one sharing
+    /// the column index. Robertson's parameters span orders of magnitude (0.04, 1e4, 3e7),
+    /// so a mix-up is unmissable.
+    #[test]
+    fn solve_dense_sensitivities_respects_sens_param_index_mapping() {
+        let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
+        let (_, sens_mapped, _, _) = solve_robertson_sens_mapped(Some(1), Some(vec![2]));
+
+        assert_eq!(sens_mapped.len(), 1, "one column was selected");
+        for j in 0..SENS_T_EVAL.len() {
+            sens_mapped[0].column(j).into_owned().assert_eq_norm(
+                &sens_full[2].column(j).into_owned(),
+                &atol,
+                rtol,
+                10.0,
+            );
+        }
+    }
+
+    /// A reduced `n_sens` must integrate fewer columns while the leading column still
+    /// tracks the full solve. Only to solver tolerance, not bit-exact: fewer columns shifts
+    /// the step sequence, so both solves are valid to the requested accuracy.
+    #[test]
+    fn solve_dense_sensitivities_respects_n_sens_override() {
+        let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
+        let (_, sens_reduced, _, _) = solve_robertson_sens(Some(1));
+
+        assert_eq!(
+            sens_reduced.len(),
+            1,
+            "only the leading sensitivity column should be integrated"
+        );
+        assert_eq!(sens_reduced[0].ncols(), SENS_T_EVAL.len());
+        assert_eq!(sens_reduced[0].nrows(), sens_full[0].nrows());
+
+        // Compare under the solver's own weighted norm, as other solve tests do.
+        for j in 0..SENS_T_EVAL.len() {
+            sens_reduced[0].column(j).into_owned().assert_eq_norm(
+                &sens_full[0].column(j).into_owned(),
+                &atol,
+                rtol,
+                10.0,
+            );
+        }
+    }
+
+    #[test]
+    fn max_index_defaults_to_nparams() {
+        let (problem, _soln) = robertson_sens::<Mcpu>();
+        let sens_eqn = SensEquations::new(&problem);
+        assert_eq!(sens_eqn.max_index(), sens_eqn.nparams());
+    }
+
+    /// `dx/dt = -p[0]·x`, `x(0) = 1`, with a reset `x -> x + p[1]` firing at `x = 0.5`.
+    /// Parameter 1 enters the problem only through the reset, so its post-event
+    /// sensitivity comes entirely from the parameter-space seed in the reset correction:
+    /// s_1(t) = exp(-p[0]·(t - t_root)) for t > t_root = ln(2)/p[0], and 0 before.
+    fn decay_with_param_dependent_reset_problem() -> OdeSolverProblem<
+        impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = crate::NalgebraContext>,
+    > {
+        use crate::OdeBuilder;
+        OdeBuilder::<Mcpu>::new()
+            .p([1.0, 0.3])
+            .rtol(1e-6)
+            .atol([1e-6])
+            .sens_rtol(1e-6)
+            .sens_atol([1e-6])
+            .rhs_sens_implicit(
+                |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = -p[0] * x[0],
+                |_x: &Vcpu, p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = -p[0] * v[0],
+                |x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = -x[0] * v[0],
+            )
+            .init_sens(
+                |_p: &Vcpu, _t, y: &mut Vcpu| y[0] = 1.0,
+                |_p: &Vcpu, _t, _v: &Vcpu, y: &mut Vcpu| y[0] = 0.0,
+                1,
+            )
+            .root_sens_implicit(
+                |x: &Vcpu, _p: &Vcpu, _t, y: &mut Vcpu| y[0] = x[0] - 0.5,
+                |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[0],
+                |_x: &Vcpu, _p: &Vcpu, _t, _v: &Vcpu, y: &mut Vcpu| y[0] = 0.0,
+                1,
+            )
+            .reset_sens_implicit(
+                |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = x[0] + p[1],
+                |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[0],
+                // dreset/dp · v = v[1]: reads the parameter-space seed at parameter 1.
+                |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[1],
+            )
+            .build()
+            .unwrap()
+    }
+
+    const RESET_SENS_T_EVAL: [f64; 3] = [0.2, 1.0, 1.5];
+
+    /// Solve [`decay_with_param_dependent_reset_problem`], optionally with only
+    /// parameter 1's sensitivity integrated (column 0 -> parameter 1).
+    fn solve_decay_reset_sens(use_bdf: bool, mapped: bool) -> (Vec<Mcpu>, Vcpu, f64) {
+        use crate::{NalgebraLU, SensitivitiesOdeSolverMethod};
+        let problem = decay_with_param_dependent_reset_problem();
+        let (atol, rtol) = (problem.atol.clone(), problem.rtol);
+        let sens = match (mapped, use_bdf) {
+            (false, false) => {
+                problem
+                    .tsit45_sens()
+                    .unwrap()
+                    .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
+                    .unwrap()
+                    .1
+            }
+            (false, true) => {
+                problem
+                    .bdf_sens::<NalgebraLU<f64>>()
+                    .unwrap()
+                    .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
+                    .unwrap()
+                    .1
+            }
+            (true, use_bdf) => {
+                let wrapped = with_sens_override(problem, 1, Some(vec![1]));
+                if use_bdf {
+                    wrapped
+                        .bdf_sens::<NalgebraLU<f64>>()
+                        .unwrap()
+                        .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
+                        .unwrap()
+                        .1
+                } else {
+                    wrapped
+                        .tsit45_sens()
+                        .unwrap()
+                        .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
+                        .unwrap()
+                        .1
+                }
+            }
+        };
+        (sens, atol, rtol)
+    }
+
+    fn assert_reset_sens_correction_respects_mapping(use_bdf: bool) {
+        let (sens_full, atol, rtol) = solve_decay_reset_sens(use_bdf, false);
+        let (sens_mapped, _, _) = solve_decay_reset_sens(use_bdf, true);
+
+        // Guard: parameter 1's sensitivity is nonzero after the event (s_1 = 2/e at
+        // t = 1), so the comparison below cannot pass vacuously.
+        let expected = 2.0 / std::f64::consts::E;
+        assert!(
+            (sens_full[1].get_index(0, 1) - expected).abs() < 1e-3,
+            "full solve s_1(1.0) should be ~{expected}, got {}",
+            sens_full[1].get_index(0, 1)
+        );
+
+        assert_eq!(sens_mapped.len(), 1, "one column was selected");
+        for j in 0..RESET_SENS_T_EVAL.len() {
+            sens_mapped[0].column(j).into_owned().assert_eq_norm(
+                &sens_full[1].column(j).into_owned(),
+                &atol,
+                rtol,
+                100.0,
+            );
+        }
+    }
+
+    /// The reset correction seeds parameter space per column; it must seed
+    /// `sens_param_index(j)`, not column `j`. Tsit45 routes through
+    /// `apply_reset_with_sens`.
+    #[test]
+    fn reset_sens_correction_respects_mapping_tsit45() {
+        assert_reset_sens_correction_respects_mapping(false);
+    }
+
+    /// As above through BDF, which routes through `apply_reset_with_sens_mass`.
+    #[test]
+    fn reset_sens_correction_respects_mapping_bdf() {
+        assert_reset_sens_correction_respects_mapping(true);
     }
 }

--- a/crates/diffsol/src/ode_equations/sens_equations.rs
+++ b/crates/diffsol/src/ode_equations/sens_equations.rs
@@ -246,14 +246,15 @@ where
 {
     pub(crate) fn new(problem: &'a OdeSolverProblem<Eqn>) -> Self {
         let eqn = &problem.eqn;
-        // `n_sens` cannot change after construction, so check the contract once here.
-        let (n_sens, nparams) = (eqn.rhs().n_sens(), eqn.rhs().nparams());
+        // `nsens` cannot change after construction, so check the contract once here.
+        let rhs = eqn.rhs();
+        let (nsens, nparams) = (rhs.nsens(), rhs.nparams());
         assert!(
-            n_sens <= nparams,
-            "Op::n_sens() must be <= Op::nparams(), got {n_sens} > {nparams}"
+            nsens <= nparams,
+            "Op::nsens() must be <= Op::nparams(), got {nsens} > {nparams}"
         );
-        for sens_col in 0..n_sens {
-            let param_index = eqn.rhs().sens_param_index(sens_col);
+        for sens_col in 0..nsens {
+            let param_index = rhs.sens_param_index(sens_col);
             assert!(
                 param_index < nparams,
                 "Op::sens_param_index({sens_col}) must be < Op::nparams(), \
@@ -360,7 +361,7 @@ impl<Eqn: OdeEquationsImplicitSens> AugmentedOdeEquations<Eqn> for SensEquations
     }
 
     fn max_index(&self) -> usize {
-        self.eqn.rhs().n_sens()
+        self.eqn.rhs().nsens()
     }
     fn update_rhs_out_state(&mut self, y: &Eqn::V, dy: &Eqn::V, t: Eqn::T) {
         self.rhs.update_state(y, dy, t);
@@ -385,10 +386,10 @@ mod tests {
             exponential_decay_with_algebraic::exponential_decay_with_algebraic_problem_sens,
             robertson::robertson_sens,
         },
-        AugmentedOdeEquations, DenseMatrix, MatrixCommon, NalgebraVec, NonLinearOp,
-        NonLinearOpJacobian, NonLinearOpSens, OdeEquations, OdeEquationsImplicit,
-        OdeEquationsImplicitSens, OdeEquationsRef, OdeSolverProblem, Op, RkState, SensEquations,
-        Vector, VectorView,
+        AugmentedOdeEquations, DenseMatrix, MatrixCommon, NalgebraContext, NalgebraLU, NalgebraVec,
+        NonLinearOp, NonLinearOpJacobian, NonLinearOpSens, OdeBuilder, OdeEquations,
+        OdeEquationsImplicit, OdeEquationsImplicitSens, OdeEquationsRef, OdeSolverProblem, Op,
+        RkState, SensEquations, SensitivitiesOdeSolverMethod, Vector, VectorView,
     };
     type Mcpu = NalgebraMat<f64>;
     type Vcpu = NalgebraVec<f64>;
@@ -521,15 +522,15 @@ mod tests {
         assert_eq!(sens.get_index(2, 2), 0.0);
     }
 
-    /// Rhs wrapper overriding `n_sens` and the column -> parameter mapping, delegating
-    /// everything else, so a test can decouple them from `nparams`.
-    struct NSensOverrideRhs<'a, Eqn: OdeEquations> {
+    /// Rhs wrapper overriding the integrated column set and the column -> parameter
+    /// mapping, delegating everything else, so a test can decouple them from `nparams`.
+    /// One column is integrated per entry of `sens_params`.
+    struct SensOverrideRhs<'a, Eqn: OdeEquations> {
         inner: <Eqn as OdeEquationsRef<'a>>::Rhs,
-        n_sens: usize,
-        sens_params: Option<Vec<usize>>,
+        sens_params: Vec<usize>,
     }
 
-    impl<Eqn: OdeEquations> Op for NSensOverrideRhs<'_, Eqn> {
+    impl<Eqn: OdeEquations> Op for SensOverrideRhs<'_, Eqn> {
         type T = Eqn::T;
         type V = Eqn::V;
         type M = Eqn::M;
@@ -546,43 +547,41 @@ mod tests {
         fn context(&self) -> &Self::C {
             self.inner.context()
         }
-        fn n_sens(&self) -> usize {
-            self.n_sens
+        fn nsens(&self) -> usize {
+            self.sens_params.len()
         }
         fn sens_param_index(&self, sens_col: usize) -> usize {
-            match &self.sens_params {
-                Some(map) => map[sens_col],
-                None => sens_col,
-            }
+            self.sens_params[sens_col]
         }
     }
 
-    impl<Eqn: OdeEquations> NonLinearOp for NSensOverrideRhs<'_, Eqn> {
+    impl<Eqn: OdeEquations> NonLinearOp for SensOverrideRhs<'_, Eqn> {
         fn call_inplace(&self, x: &Self::V, t: Self::T, y: &mut Self::V) {
             self.inner.call_inplace(x, t, y)
         }
     }
 
-    impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for NSensOverrideRhs<'_, Eqn> {
+    impl<Eqn: OdeEquationsImplicit> NonLinearOpJacobian for SensOverrideRhs<'_, Eqn> {
         fn jac_mul_inplace(&self, x: &Self::V, t: Self::T, v: &Self::V, y: &mut Self::V) {
             self.inner.jac_mul_inplace(x, t, v, y)
         }
     }
 
-    impl<Eqn: OdeEquationsImplicitSens> NonLinearOpSens for NSensOverrideRhs<'_, Eqn> {
+    impl<Eqn: OdeEquationsImplicitSens> NonLinearOpSens for SensOverrideRhs<'_, Eqn> {
         fn sens_mul_inplace(&self, x: &Self::V, t: Self::T, v: &Self::V, y: &mut Self::V) {
             self.inner.sens_mul_inplace(x, t, v, y)
         }
     }
 
-    /// Equations wrapper that swaps in [`NSensOverrideRhs`] for the rhs op.
-    struct NSensOverrideEqn<Eqn> {
+    /// Equations wrapper that swaps in [`SensOverrideRhs`] for the rhs op. Note that the
+    /// override has to live on the rhs: this struct's own [`Op`] impl is never consulted
+    /// for `nsens`, so it forwards `nparams` unchanged.
+    struct SensOverrideEqn<Eqn> {
         inner: Eqn,
-        n_sens: usize,
-        sens_params: Option<Vec<usize>>,
+        sens_params: Vec<usize>,
     }
 
-    impl<Eqn: OdeEquations> Op for NSensOverrideEqn<Eqn> {
+    impl<Eqn: OdeEquations> Op for SensOverrideEqn<Eqn> {
         type T = Eqn::T;
         type V = Eqn::V;
         type M = Eqn::M;
@@ -601,20 +600,19 @@ mod tests {
         }
     }
 
-    impl<'a, Eqn: OdeEquationsImplicitSens> OdeEquationsRef<'a> for NSensOverrideEqn<Eqn> {
+    impl<'a, Eqn: OdeEquationsImplicitSens> OdeEquationsRef<'a> for SensOverrideEqn<Eqn> {
         type Mass = <Eqn as OdeEquationsRef<'a>>::Mass;
-        type Rhs = NSensOverrideRhs<'a, Eqn>;
+        type Rhs = SensOverrideRhs<'a, Eqn>;
         type Root = <Eqn as OdeEquationsRef<'a>>::Root;
         type Init = <Eqn as OdeEquationsRef<'a>>::Init;
         type Out = <Eqn as OdeEquationsRef<'a>>::Out;
         type Reset = <Eqn as OdeEquationsRef<'a>>::Reset;
     }
 
-    impl<Eqn: OdeEquationsImplicitSens> OdeEquations for NSensOverrideEqn<Eqn> {
+    impl<Eqn: OdeEquationsImplicitSens> OdeEquations for SensOverrideEqn<Eqn> {
         fn rhs(&self) -> <Self as OdeEquationsRef<'_>>::Rhs {
-            NSensOverrideRhs {
+            SensOverrideRhs {
                 inner: self.inner.rhs(),
-                n_sens: self.n_sens,
                 sens_params: self.sens_params.clone(),
             }
         }
@@ -641,24 +639,15 @@ mod tests {
         }
     }
 
-    /// Rebuild `problem` around an [`NSensOverrideEqn`], keeping every tolerance.
-    fn with_n_sens_override<Eqn: OdeEquationsImplicitSens>(
-        problem: OdeSolverProblem<Eqn>,
-        n_sens: usize,
-    ) -> OdeSolverProblem<NSensOverrideEqn<Eqn>> {
-        with_sens_override(problem, n_sens, None)
-    }
-
-    /// As [`with_n_sens_override`], but also installing a column -> parameter mapping.
+    /// Rebuild `problem` around a [`SensOverrideEqn`] integrating one sensitivity column
+    /// per entry of `sens_params`, keeping every tolerance.
     fn with_sens_override<Eqn: OdeEquationsImplicitSens>(
         problem: OdeSolverProblem<Eqn>,
-        n_sens: usize,
-        sens_params: Option<Vec<usize>>,
-    ) -> OdeSolverProblem<NSensOverrideEqn<Eqn>> {
+        sens_params: Vec<usize>,
+    ) -> OdeSolverProblem<SensOverrideEqn<Eqn>> {
         OdeSolverProblem::new(
-            NSensOverrideEqn {
+            SensOverrideEqn {
                 inner: problem.eqn,
-                n_sens,
                 sens_params,
             },
             problem.rtol,
@@ -679,9 +668,9 @@ mod tests {
     }
 
     #[test]
-    fn max_index_respects_n_sens_override() {
+    fn max_index_respects_nsens_override() {
         let (problem, _soln) = robertson_sens::<Mcpu>();
-        let wrapped_problem = with_n_sens_override(problem, 1);
+        let wrapped_problem = with_sens_override(problem, vec![0]);
         let sens_eqn = SensEquations::new(&wrapped_problem);
         assert_eq!(sens_eqn.nparams(), 3);
         assert_eq!(sens_eqn.max_index(), 1);
@@ -690,10 +679,10 @@ mod tests {
     /// Checked at construction, so it fires in release too rather than as an opaque
     /// out-of-bounds panic mid-solve.
     #[test]
-    #[should_panic(expected = "Op::n_sens() must be <= Op::nparams(), got 5 > 3")]
-    fn sens_equations_new_rejects_n_sens_above_nparams() {
+    #[should_panic(expected = "Op::nsens() must be <= Op::nparams(), got 5 > 3")]
+    fn sens_equations_new_rejects_nsens_above_nparams() {
         let (problem, _soln) = robertson_sens::<Mcpu>();
-        let wrapped_problem = with_n_sens_override(problem, 5);
+        let wrapped_problem = with_sens_override(problem, vec![0, 1, 2, 0, 1]);
         let _ = SensEquations::new(&wrapped_problem);
     }
 
@@ -702,54 +691,57 @@ mod tests {
     #[should_panic(expected = "Op::sens_param_index(0) must be < Op::nparams(), got 7 >= 3")]
     fn sens_equations_new_rejects_out_of_range_sens_param_index() {
         let (problem, _soln) = robertson_sens::<Mcpu>();
-        let wrapped_problem = with_sens_override(problem, 1, Some(vec![7]));
+        let wrapped_problem = with_sens_override(problem, vec![7]);
         let _ = SensEquations::new(&wrapped_problem);
+    }
+
+    /// Solve for state and sensitivities at `t_eval`, through BDF or Tsit45. Generic over
+    /// the equations so wrapped and unwrapped problems share one call site.
+    fn solve_dense_sens<Eqn>(
+        problem: OdeSolverProblem<Eqn>,
+        t_eval: &[f64],
+        use_bdf: bool,
+    ) -> (Mcpu, Vec<Mcpu>)
+    where
+        Eqn: OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
+    {
+        let (y, sens, _) = if use_bdf {
+            problem
+                .bdf_sens::<NalgebraLU<f64>>()
+                .unwrap()
+                .solve_dense_sensitivities(t_eval)
+                .unwrap()
+        } else {
+            problem
+                .tsit45_sens()
+                .unwrap()
+                .solve_dense_sensitivities(t_eval)
+                .unwrap()
+        };
+        (y, sens)
     }
 
     const SENS_T_EVAL: [f64; 3] = [1e-4, 1e-2, 1.0];
 
-    /// Solve `robertson_sens`, optionally with a reduced `n_sens`. Returns the state, the
-    /// sensitivity columns at [`SENS_T_EVAL`], and the tolerances for comparing solves.
-    fn solve_robertson_sens(n_sens_override: Option<usize>) -> (Mcpu, Vec<Mcpu>, Vcpu, f64) {
-        solve_robertson_sens_mapped(n_sens_override, None)
-    }
-
-    /// As [`solve_robertson_sens`], but able to install a column -> parameter mapping.
-    fn solve_robertson_sens_mapped(
-        n_sens_override: Option<usize>,
-        sens_params: Option<Vec<usize>>,
-    ) -> (Mcpu, Vec<Mcpu>, Vcpu, f64) {
-        use crate::{NalgebraLU, SensitivitiesOdeSolverMethod};
+    /// Solve `robertson_sens`, optionally wrapped to integrate only `sens_params`. Returns
+    /// the state, the sensitivity columns at [`SENS_T_EVAL`], and the tolerances for
+    /// comparing solves.
+    fn solve_robertson_sens(sens_params: Option<Vec<usize>>) -> (Mcpu, Vec<Mcpu>, Vcpu, f64) {
         let (problem, _soln) = robertson_sens::<Mcpu>();
         let (atol, rtol) = (problem.atol.clone(), problem.rtol);
-        let (y, sens) = match n_sens_override {
-            None => {
-                let (y, sens, _) = problem
-                    .bdf_sens::<NalgebraLU<f64>>()
-                    .unwrap()
-                    .solve_dense_sensitivities(&SENS_T_EVAL)
-                    .unwrap();
-                (y, sens)
-            }
-            Some(n_sens) => {
-                let wrapped = with_sens_override(problem, n_sens, sens_params);
-                let (y, sens, _) = wrapped
-                    .bdf_sens::<NalgebraLU<f64>>()
-                    .unwrap()
-                    .solve_dense_sensitivities(&SENS_T_EVAL)
-                    .unwrap();
-                (y, sens)
-            }
+        let (y, sens) = match sens_params {
+            None => solve_dense_sens(problem, &SENS_T_EVAL, true),
+            Some(map) => solve_dense_sens(with_sens_override(problem, map), &SENS_T_EVAL, true),
         };
         (y, sens, atol, rtol)
     }
 
-    /// With `n_sens == nparams` the override plumbing must reproduce the unwrapped solve
-    /// bit-for-bit, so the default path is provably untouched.
+    /// With `nsens == nparams` and an identity mapping the override plumbing must reproduce
+    /// the unwrapped solve bit-for-bit, so the default path is provably untouched.
     #[test]
-    fn solve_dense_sensitivities_bit_identical_when_n_sens_equals_nparams() {
+    fn solve_dense_sensitivities_bit_identical_when_nsens_equals_nparams() {
         let (y_full, sens_full, _, _) = solve_robertson_sens(None);
-        let (y_wrapped, sens_wrapped, _, _) = solve_robertson_sens(Some(3));
+        let (y_wrapped, sens_wrapped, _, _) = solve_robertson_sens(Some(vec![0, 1, 2]));
 
         assert_eq!(sens_full.len(), 3, "robertson_sens has 3 parameters");
         assert_eq!(y_full, y_wrapped, "state trajectory must be bit-identical");
@@ -765,7 +757,7 @@ mod tests {
     #[test]
     fn solve_dense_sensitivities_respects_sens_param_index_mapping() {
         let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
-        let (_, sens_mapped, _, _) = solve_robertson_sens_mapped(Some(1), Some(vec![2]));
+        let (_, sens_mapped, _, _) = solve_robertson_sens(Some(vec![2]));
 
         assert_eq!(sens_mapped.len(), 1, "one column was selected");
         for j in 0..SENS_T_EVAL.len() {
@@ -778,13 +770,13 @@ mod tests {
         }
     }
 
-    /// A reduced `n_sens` must integrate fewer columns while the leading column still
+    /// A reduced `nsens` must integrate fewer columns while the leading column still
     /// tracks the full solve. Only to solver tolerance, not bit-exact: fewer columns shifts
     /// the step sequence, so both solves are valid to the requested accuracy.
     #[test]
-    fn solve_dense_sensitivities_respects_n_sens_override() {
+    fn solve_dense_sensitivities_respects_nsens_override() {
         let (_, sens_full, atol, rtol) = solve_robertson_sens(None);
-        let (_, sens_reduced, _, _) = solve_robertson_sens(Some(1));
+        let (_, sens_reduced, _, _) = solve_robertson_sens(Some(vec![0]));
 
         assert_eq!(
             sens_reduced.len(),
@@ -805,21 +797,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn max_index_defaults_to_nparams() {
-        let (problem, _soln) = robertson_sens::<Mcpu>();
-        let sens_eqn = SensEquations::new(&problem);
-        assert_eq!(sens_eqn.max_index(), sens_eqn.nparams());
-    }
-
     /// `dx/dt = -p[0]·x`, `x(0) = 1`, with a reset `x -> x + p[1]` firing at `x = 0.5`.
     /// Parameter 1 enters the problem only through the reset, so its post-event
     /// sensitivity comes entirely from the parameter-space seed in the reset correction:
     /// s_1(t) = exp(-p[0]·(t - t_root)) for t > t_root = ln(2)/p[0], and 0 before.
     fn decay_with_param_dependent_reset_problem() -> OdeSolverProblem<
-        impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = crate::NalgebraContext>,
+        impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
     > {
-        use crate::OdeBuilder;
         OdeBuilder::<Mcpu>::new()
             .p([1.0, 0.3])
             .rtol(1e-6)
@@ -857,44 +841,17 @@ mod tests {
     /// Solve [`decay_with_param_dependent_reset_problem`], optionally with only
     /// parameter 1's sensitivity integrated (column 0 -> parameter 1).
     fn solve_decay_reset_sens(use_bdf: bool, mapped: bool) -> (Vec<Mcpu>, Vcpu, f64) {
-        use crate::{NalgebraLU, SensitivitiesOdeSolverMethod};
         let problem = decay_with_param_dependent_reset_problem();
         let (atol, rtol) = (problem.atol.clone(), problem.rtol);
-        let sens = match (mapped, use_bdf) {
-            (false, false) => {
-                problem
-                    .tsit45_sens()
-                    .unwrap()
-                    .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
-                    .unwrap()
-                    .1
-            }
-            (false, true) => {
-                problem
-                    .bdf_sens::<NalgebraLU<f64>>()
-                    .unwrap()
-                    .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
-                    .unwrap()
-                    .1
-            }
-            (true, use_bdf) => {
-                let wrapped = with_sens_override(problem, 1, Some(vec![1]));
-                if use_bdf {
-                    wrapped
-                        .bdf_sens::<NalgebraLU<f64>>()
-                        .unwrap()
-                        .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
-                        .unwrap()
-                        .1
-                } else {
-                    wrapped
-                        .tsit45_sens()
-                        .unwrap()
-                        .solve_dense_sensitivities(&RESET_SENS_T_EVAL)
-                        .unwrap()
-                        .1
-                }
-            }
+        let sens = if mapped {
+            solve_dense_sens(
+                with_sens_override(problem, vec![1]),
+                &RESET_SENS_T_EVAL,
+                use_bdf,
+            )
+            .1
+        } else {
+            solve_dense_sens(problem, &RESET_SENS_T_EVAL, use_bdf).1
         };
         (sens, atol, rtol)
     }
@@ -935,5 +892,105 @@ mod tests {
     #[test]
     fn reset_sens_correction_respects_mapping_bdf() {
         assert_reset_sens_correction_respects_mapping(true);
+    }
+
+    /// `nsens() == 0` is the degenerate end of the documented range: nothing to integrate,
+    /// while the main equation (reset and all) still solves.
+    #[test]
+    fn solve_dense_sensitivities_with_no_columns() {
+        for use_bdf in [true, false] {
+            let problem = with_sens_override(decay_with_param_dependent_reset_problem(), vec![]);
+            let (y, sens) = solve_dense_sens(problem, &RESET_SENS_T_EVAL, use_bdf);
+            assert!(sens.is_empty());
+            assert_eq!(y.ncols(), RESET_SENS_T_EVAL.len());
+            assert_eq!(y.nrows(), 1);
+        }
+    }
+
+    /// `dx/dt = -p[0]·x`, `x(0) = 1`, output `g = x + p[1]`, root at `x = 0.5` and no
+    /// reset. Parameter 1 enters only through the output, so `dg/dp[1] = 1` exactly and
+    /// the out-sensitivity seed is the only thing that can produce it.
+    fn decay_with_out_problem() -> OdeSolverProblem<
+        impl OdeEquationsImplicitSens<M = Mcpu, V = Vcpu, T = f64, C = NalgebraContext>,
+    > {
+        OdeBuilder::<Mcpu>::new()
+            .p([1.0, 0.3])
+            .rtol(1e-6)
+            .atol([1e-6])
+            .sens_rtol(1e-6)
+            .sens_atol([1e-6])
+            .rhs_sens_implicit(
+                |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = -p[0] * x[0],
+                |_x: &Vcpu, p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = -p[0] * v[0],
+                |x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = -x[0] * v[0],
+            )
+            .init_sens(
+                |_p: &Vcpu, _t, y: &mut Vcpu| y[0] = 1.0,
+                |_p: &Vcpu, _t, _v: &Vcpu, y: &mut Vcpu| y[0] = 0.0,
+                1,
+            )
+            .root_sens_implicit(
+                |x: &Vcpu, _p: &Vcpu, _t, y: &mut Vcpu| y[0] = x[0] - 0.5,
+                |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[0],
+                |_x: &Vcpu, _p: &Vcpu, _t, _v: &Vcpu, y: &mut Vcpu| y[0] = 0.0,
+                1,
+            )
+            .out_sens_implicit(
+                |x: &Vcpu, p: &Vcpu, _t, y: &mut Vcpu| y[0] = x[0] + p[1],
+                |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[0],
+                // dg/dp · v = v[1]: reads the parameter-space seed at parameter 1.
+                |_x: &Vcpu, _p: &Vcpu, _t, v: &Vcpu, y: &mut Vcpu| y[0] = v[1],
+                1,
+            )
+            .build()
+            .unwrap()
+    }
+
+    /// The root at `x = 0.5` fires at `t = ln(2)`, between the second and third entry, so
+    /// the final column is written by `write_state_sens_out` rather than by the
+    /// interpolating path.
+    const OUT_SENS_T_EVAL: [f64; 3] = [0.2, 0.5, 1.0];
+
+    /// Both out-sensitivity seed sites are parameter-space: they must seed
+    /// `sens_param_index(j)`, not column `j`.
+    #[test]
+    fn out_sens_respects_mapping() {
+        let (y_full, sens_full) =
+            solve_dense_sens(decay_with_out_problem(), &OUT_SENS_T_EVAL, true);
+        let (_, sens_mapped) = solve_dense_sens(
+            with_sens_override(decay_with_out_problem(), vec![1]),
+            &OUT_SENS_T_EVAL,
+            true,
+        );
+
+        // The last column is the root time, so g = 0.5 + p[1]; confirms the solve stopped
+        // on the root and the `write_state_sens_out` path ran.
+        assert_eq!(y_full.ncols(), OUT_SENS_T_EVAL.len());
+        assert!(
+            (y_full.get_index(0, 2) - 0.8).abs() < 1e-5,
+            "expected the final column at the root, got g = {}",
+            y_full.get_index(0, 2)
+        );
+
+        // Guard: dg/dp[0] = -t·exp(-t) is nowhere near dg/dp[1] = 1, so seeding the wrong
+        // index cannot pass. A wrong seed gives 0 for the mapped column.
+        assert_eq!(sens_full.len(), 2);
+        let expected_p0 = -0.2 * (-0.2f64).exp();
+        assert!(
+            (sens_full[0].get_index(0, 0) - expected_p0).abs() < 1e-4,
+            "full solve dg/dp[0](0.2) should be ~{expected_p0}, got {}",
+            sens_full[0].get_index(0, 0)
+        );
+
+        assert_eq!(sens_mapped.len(), 1, "one column was selected");
+        for j in 0..OUT_SENS_T_EVAL.len() {
+            for sens in [&sens_full[1], &sens_mapped[0]] {
+                assert!(
+                    (sens.get_index(0, j) - 1.0).abs() < 1e-4,
+                    "dg/dp[1] should be 1 at every column, got {} at column {j}",
+                    sens.get_index(0, j)
+                );
+            }
+        }
     }
 }

--- a/crates/diffsol/src/ode_solver/bdf_state.rs
+++ b/crates/diffsol/src/ode_solver/bdf_state.rs
@@ -148,7 +148,7 @@ where
     ) -> Result<(), DiffsolError> {
         let naug = augmented_eqn.max_index();
         let nstates = ode_problem.eqn.rhs().nstates();
-        if self.sdiff.len() != naug || self.sdiff[0].nrows() != nstates {
+        if self.sdiff.len() != naug || (naug > 0 && self.sdiff[0].nrows() != nstates) {
             return Err(ode_solver_error!(StateProblemMismatch));
         }
         let (sgdiff_len, sgdiff_size) = if let Some(out) = augmented_eqn.out() {

--- a/crates/diffsol/src/ode_solver/builder.rs
+++ b/crates/diffsol/src/ode_solver/builder.rs
@@ -31,6 +31,7 @@ pub struct OdeBuilder<
     atol: Vec<M::T>,
     sens_atol: Option<Vec<M::T>>,
     sens_rtol: Option<M::T>,
+    sens_params: Option<Vec<usize>>,
     out_rtol: Option<M::T>,
     out_atol: Option<Vec<M::T>>,
     param_rtol: Option<M::T>,
@@ -128,6 +129,7 @@ where
             param_atol: None,
             sens_atol: None,
             sens_rtol: None,
+            sens_params: None,
             ctx: M::C::default(),
             ic_options: Default::default(),
             ode_options: Default::default(),
@@ -164,6 +166,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -214,6 +217,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -268,6 +272,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -329,6 +334,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -368,6 +374,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -416,6 +423,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -465,6 +473,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -507,6 +516,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -559,6 +569,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -606,6 +617,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -662,6 +674,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -722,6 +735,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -767,6 +781,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -819,6 +834,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -872,6 +888,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -929,6 +946,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -982,6 +1000,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -1040,6 +1059,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -1102,6 +1122,7 @@ where
             atol: self.atol,
             sens_atol: self.sens_atol,
             sens_rtol: self.sens_rtol,
+            sens_params: self.sens_params,
             out_rtol: self.out_rtol,
             out_atol: self.out_atol,
             param_rtol: self.param_rtol,
@@ -1135,6 +1156,17 @@ where
     /// fallback so that sensitivity equations always contribute to error control.
     pub fn sens_rtol(mut self, sens_rtol: f64) -> Self {
         self.sens_rtol = Some(M::T::from_f64(sens_rtol).unwrap());
+        self
+    }
+
+    /// Set the parameters to integrate forward sensitivities for, as indices into [`p`](Self::p).
+    ///
+    /// If not set, one sensitivity column is integrated per parameter, in parameter order.
+    /// The ith column of the solve output is then the sensitivity with respect to `sens_params[i]`.
+    /// Only reaches an rhs built by [`rhs_sens_implicit`](Self::rhs_sens_implicit), and is ignored otherwise.
+    /// Indices are validated when the sensitivity equations are constructed, not here.
+    pub fn sens_params(mut self, sens_params: impl IntoIterator<Item = usize>) -> Self {
+        self.sens_params = Some(sens_params.into_iter().collect());
         self
     }
 
@@ -1457,6 +1489,7 @@ where
         rhs.set_nstates(nstates);
         rhs.set_nout(nstates);
         rhs.set_nparams(nparams);
+        rhs.set_sens_params(self.sens_params);
 
         init.set_nout(nstates);
         init.set_nparams(nparams);

--- a/crates/diffsol/src/ode_solver/sensitivities.rs
+++ b/crates/diffsol/src/ode_solver/sensitivities.rs
@@ -50,7 +50,7 @@ where
             .map(|out| out.nout())
             .unwrap_or_else(|| self.problem().eqn.rhs().nout());
         let nstates = self.problem().eqn.rhs().nstates();
-        let nsens = self.problem().eqn.rhs().n_sens();
+        let nsens = self.problem().eqn.rhs().nsens();
         let nout = self.problem().eqn.out().map(|out| out.nout()).unwrap_or(0);
         let nout_params = self
             .problem()
@@ -100,7 +100,10 @@ where
     /// plus one final column at the root time if a root fires before `t_eval` is exhausted and no reset operator is configured.
     ///
     /// The sensitivities are returned as a Vec of dense matrices of identical shape as the ODE solution,
-    /// where the ith element of the Vec corresponds to the sensitivities with respect to the ith parameter.
+    /// with one element per integrated sensitivity column, i.e. `eqn.rhs().nsens()` of them.
+    /// By default that is one per parameter, in parameter order; if the equations override
+    /// [`Op::nsens`], the ith element is the sensitivity with respect to parameter
+    /// `eqn.rhs().sens_param_index(i)`.
     /// `stop_reason` indicates whether the solve reached `t_eval[t_eval.len()-1]` or stopped on a root.
     ///
     /// # Post-condition
@@ -140,7 +143,7 @@ where
             self.problem().eqn.rhs().nout()
         };
         let nstates = self.problem().eqn.rhs().nstates();
-        let nsens = self.problem().eqn.rhs().n_sens();
+        let nsens = self.problem().eqn.rhs().nsens();
         let ctx = self.problem().context().clone();
 
         let mut ret = ctx.dense_mat_zeros::<Eqn::V>(nrows, t_eval.len());

--- a/crates/diffsol/src/ode_solver/sensitivities.rs
+++ b/crates/diffsol/src/ode_solver/sensitivities.rs
@@ -100,10 +100,8 @@ where
     /// plus one final column at the root time if a root fires before `t_eval` is exhausted and no reset operator is configured.
     ///
     /// The sensitivities are returned as a Vec of dense matrices of identical shape as the ODE solution,
-    /// with one element per integrated sensitivity column, i.e. `eqn.rhs().nsens()` of them.
-    /// By default that is one per parameter, in parameter order; if the equations override
-    /// [`Op::nsens`], the ith element is the sensitivity with respect to parameter
-    /// `eqn.rhs().sens_param_index(i)`.
+    /// with one element per integrated sensitivity column, i.e. `eqn.rhs().nsens()` of them (by default one per parameter, in parameter order).
+    /// The ith element is the sensitivity with respect to parameter `eqn.rhs().sens_param_index(i)`.
     /// `stop_reason` indicates whether the solve reached `t_eval[t_eval.len()-1]` or stopped on a root.
     ///
     /// # Post-condition
@@ -383,7 +381,7 @@ where
         ret.column_mut(col).copy_from(tmp_nout);
         let rhs = s.problem().eqn.rhs();
         for (j, s_j) in tmp_nsens.iter().enumerate() {
-            // `tmp_nparams` is a parameter-space seed, so seed column j's parameter.
+            // the seed is parameter-space, so index by parameter and not by column
             let param_index = rhs.sens_param_index(j);
             let mut col_v = ret_sens[j].column_mut(col);
             tmp_nparams.set_index(param_index, Eqn::T::one());
@@ -419,7 +417,7 @@ pub(crate) fn write_state_sens_out<Eqn>(
             if j >= ret_sens.len() {
                 break;
             }
-            // `tmp_nparams` is a parameter-space seed, so seed column j's parameter.
+            // the seed is parameter-space, so index by parameter and not by column
             let param_index = rhs.sens_param_index(j);
             let mut col_v = ret_sens[j].column_mut(col);
             tmp_nparams.set_index(param_index, Eqn::T::one());

--- a/crates/diffsol/src/ode_solver/sensitivities.rs
+++ b/crates/diffsol/src/ode_solver/sensitivities.rs
@@ -50,7 +50,7 @@ where
             .map(|out| out.nout())
             .unwrap_or_else(|| self.problem().eqn.rhs().nout());
         let nstates = self.problem().eqn.rhs().nstates();
-        let nparams = self.problem().eqn.rhs().nparams();
+        let nsens = self.problem().eqn.rhs().n_sens();
         let nout = self.problem().eqn.out().map(|out| out.nout()).unwrap_or(0);
         let nout_params = self
             .problem()
@@ -58,7 +58,7 @@ where
             .out()
             .map(|out| out.nparams())
             .unwrap_or(0);
-        soln.ensure_sens_allocation(&ctx, nrows, nout, nout_params, nstates, nparams)?;
+        soln.ensure_sens_allocation(&ctx, nrows, nout, nout_params, nstates, nsens)?;
 
         let (stop_reason, col) = solve_dense_sensitivities(
             &mut soln.ys,
@@ -140,11 +140,11 @@ where
             self.problem().eqn.rhs().nout()
         };
         let nstates = self.problem().eqn.rhs().nstates();
-        let nparams = self.problem().eqn.rhs().nparams();
+        let nsens = self.problem().eqn.rhs().n_sens();
         let ctx = self.problem().context().clone();
 
         let mut ret = ctx.dense_mat_zeros::<Eqn::V>(nrows, t_eval.len());
-        let mut ret_sens = vec![ctx.dense_mat_zeros::<Eqn::V>(nrows, t_eval.len()); nparams];
+        let mut ret_sens = vec![ctx.dense_mat_zeros::<Eqn::V>(nrows, t_eval.len()); nsens];
         let mut tmp_nout = Eqn::V::zeros(
             self.problem().eqn.out().map(|out| out.nout()).unwrap_or(0),
             ctx.clone(),
@@ -158,7 +158,7 @@ where
             ctx.clone(),
         );
         let mut tmp_nstates = Eqn::V::zeros(nstates, ctx.clone());
-        let mut tmp_nsens = vec![Eqn::V::zeros(nstates, ctx); nparams];
+        let mut tmp_nsens = vec![Eqn::V::zeros(nstates, ctx); nsens];
 
         // check t_eval is increasing and all values are >= the current time
         let t0 = self.state().t;
@@ -378,14 +378,17 @@ where
     if let Some(out) = s.problem().eqn.out() {
         out.call_inplace(tmp_nstates, t, tmp_nout);
         ret.column_mut(col).copy_from(tmp_nout);
+        let rhs = s.problem().eqn.rhs();
         for (j, s_j) in tmp_nsens.iter().enumerate() {
+            // `tmp_nparams` is a parameter-space seed, so seed column j's parameter.
+            let param_index = rhs.sens_param_index(j);
             let mut col_v = ret_sens[j].column_mut(col);
-            tmp_nparams.set_index(j, Eqn::T::one());
+            tmp_nparams.set_index(param_index, Eqn::T::one());
             out.jac_mul_inplace(tmp_nstates, t, s_j, tmp_nout);
             col_v.copy_from(&*tmp_nout);
             out.sens_mul_inplace(tmp_nstates, t, tmp_nparams, tmp_nout);
             col_v.add_assign(&*tmp_nout);
-            tmp_nparams.set_index(j, Eqn::T::zero());
+            tmp_nparams.set_index(param_index, Eqn::T::zero());
         }
     } else {
         ret.column_mut(col).copy_from(tmp_nstates);
@@ -408,17 +411,20 @@ pub(crate) fn write_state_sens_out<Eqn>(
     Eqn::V: DefaultDenseMatrix,
 {
     if let Some(out) = problem.eqn.out() {
+        let rhs = problem.eqn.rhs();
         for (j, state_sens) in state.s.iter().enumerate() {
             if j >= ret_sens.len() {
                 break;
             }
+            // `tmp_nparams` is a parameter-space seed, so seed column j's parameter.
+            let param_index = rhs.sens_param_index(j);
             let mut col_v = ret_sens[j].column_mut(col);
-            tmp_nparams.set_index(j, Eqn::T::one());
+            tmp_nparams.set_index(param_index, Eqn::T::one());
             out.jac_mul_inplace(state.y, state.t, state_sens, tmp_nout);
             col_v.copy_from(&*tmp_nout);
             out.sens_mul_inplace(state.y, state.t, tmp_nparams, tmp_nout);
             col_v.add_assign(&*tmp_nout);
-            tmp_nparams.set_index(j, Eqn::T::zero());
+            tmp_nparams.set_index(param_index, Eqn::T::zero());
         }
     } else {
         for (sens, state_sens) in ret_sens.iter_mut().zip(state.s.iter()) {

--- a/crates/diffsol/src/ode_solver/solution.rs
+++ b/crates/diffsol/src/ode_solver/solution.rs
@@ -278,17 +278,14 @@ impl<V: DefaultDenseMatrix> Solution<V> {
         nout: usize,
         nout_params: usize,
         nstates: usize,
-        nparams: usize,
+        nsens: usize,
     ) -> Result<(), DiffsolError> {
         self.ensure_ode_allocation(ctx, nrows, nout, nstates)?;
 
         if self.y_sens.is_empty() {
             self.y_sens =
-                vec![
-                    <V as DefaultDenseMatrix>::M::zeros(nrows, self.ts.len(), ctx.clone());
-                    nparams
-                ];
-        } else if self.y_sens.len() != nparams
+                vec![<V as DefaultDenseMatrix>::M::zeros(nrows, self.ts.len(), ctx.clone()); nsens];
+        } else if self.y_sens.len() != nsens
             || self
                 .y_sens
                 .iter()
@@ -310,9 +307,8 @@ impl<V: DefaultDenseMatrix> Solution<V> {
         }
 
         if self.tmp_nsens.is_empty() {
-            self.tmp_nsens = vec![V::zeros(nstates, ctx.clone()); nparams];
-        } else if self.tmp_nsens.len() != nparams
-            || self.tmp_nsens.iter().any(|v| v.len() != nstates)
+            self.tmp_nsens = vec![V::zeros(nstates, ctx.clone()); nsens];
+        } else if self.tmp_nsens.len() != nsens || self.tmp_nsens.iter().any(|v| v.len() != nstates)
         {
             return Err(ode_solver_error!(
                 Other,

--- a/crates/diffsol/src/ode_solver/state.rs
+++ b/crates/diffsol/src/ode_solver/state.rs
@@ -379,7 +379,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let nbatch = correction_dir.context().nbatch();
         let mut s_plus = Vec::with_capacity(nsens);
         for (j, s_j_before) in s_before.iter().enumerate() {
-            // `basis` is a parameter-space seed, so seed column j's parameter.
+            // the seed is parameter-space, so index by parameter and not by column
             let param_index = rhs.sens_param_index(j);
             basis.set_index(param_index, V::T::one());
 
@@ -487,7 +487,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let nbatch = correction_dir.context().nbatch();
         let mut s_plus = Vec::with_capacity(nsens);
         for (j, s_j_before) in s_before.iter().enumerate() {
-            // `basis` is a parameter-space seed, so seed column j's parameter.
+            // the seed is parameter-space, so index by parameter and not by column
             let param_index = rhs.sens_param_index(j);
             basis.set_index(param_index, V::T::one());
 

--- a/crates/diffsol/src/ode_solver/state.rs
+++ b/crates/diffsol/src/ode_solver/state.rs
@@ -344,7 +344,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let y_before = self.y.clone();
         let f_minus = self.dy.clone();
         let s_before = self.s.to_vec();
-        let nparams = s_before.len();
+        let n_sens = s_before.len();
         let reset_t = reset_op.time_derive(&y_before, t);
         let root_t = root_op.time_derive(&y_before, t);
 
@@ -371,15 +371,17 @@ impl<V: Vector> StateRefMut<'_, V> {
             }
         }
 
-        let mut basis = V::zeros(nparams, ctx.clone());
+        let mut basis = V::zeros(rhs.nparams(), ctx.clone());
         let mut reset_jac_s = V::zeros(nstates, ctx.clone());
         let mut reset_sens = V::zeros(nstates, ctx.clone());
         let mut root_jac_s = V::zeros(nroots, ctx.clone());
         let mut root_sens = V::zeros(nroots, ctx);
         let nbatch = correction_dir.context().nbatch();
-        let mut s_plus = Vec::with_capacity(nparams);
+        let mut s_plus = Vec::with_capacity(n_sens);
         for (j, s_j_before) in s_before.iter().enumerate() {
-            basis.set_index(j, V::T::one());
+            // `basis` is a parameter-space seed, so seed column j's parameter.
+            let param_index = rhs.sens_param_index(j);
+            basis.set_index(param_index, V::T::one());
 
             reset_op.jac_mul_inplace(&y_before, t, s_j_before, &mut reset_jac_s);
             reset_op.sens_mul_inplace(&y_before, t, &basis, &mut reset_sens);
@@ -401,7 +403,7 @@ impl<V: Vector> StateRefMut<'_, V> {
             s_j_plus.batched_axpy(&tau_p, &correction_dir, V::T::one());
             s_plus.push(s_j_plus);
 
-            basis.set_index(j, V::T::zero());
+            basis.set_index(param_index, V::T::zero());
         }
 
         for (dst, src) in self.s.iter_mut().zip(s_plus.iter()) {
@@ -450,7 +452,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let y_before = self.y.clone();
         let f_minus = self.dy.clone();
         let s_before = self.s.to_vec();
-        let nparams = s_before.len();
+        let n_sens = s_before.len();
         let reset_t = reset_op.time_derive(&y_before, t);
         let root_t = root_op.time_derive(&y_before, t);
 
@@ -477,15 +479,17 @@ impl<V: Vector> StateRefMut<'_, V> {
             }
         }
 
-        let mut basis = V::zeros(nparams, ctx.clone());
+        let mut basis = V::zeros(rhs.nparams(), ctx.clone());
         let mut reset_jac_s = V::zeros(nstates, ctx.clone());
         let mut reset_sens = V::zeros(nstates, ctx.clone());
         let mut root_jac_s = V::zeros(nroots, ctx.clone());
         let mut root_sens = V::zeros(nroots, ctx);
         let nbatch = correction_dir.context().nbatch();
-        let mut s_plus = Vec::with_capacity(nparams);
+        let mut s_plus = Vec::with_capacity(n_sens);
         for (j, s_j_before) in s_before.iter().enumerate() {
-            basis.set_index(j, V::T::one());
+            // `basis` is a parameter-space seed, so seed column j's parameter.
+            let param_index = rhs.sens_param_index(j);
+            basis.set_index(param_index, V::T::one());
 
             reset_op.jac_mul_inplace(&y_before, t, s_j_before, &mut reset_jac_s);
             reset_op.sens_mul_inplace(&y_before, t, &basis, &mut reset_sens);
@@ -507,7 +511,7 @@ impl<V: Vector> StateRefMut<'_, V> {
             s_j_plus.batched_axpy(&tau_p, &correction_dir, V::T::one());
             s_plus.push(s_j_plus);
 
-            basis.set_index(j, V::T::zero());
+            basis.set_index(param_index, V::T::zero());
         }
 
         for (dst, src) in self.s.iter_mut().zip(s_plus.iter()) {

--- a/crates/diffsol/src/ode_solver/state.rs
+++ b/crates/diffsol/src/ode_solver/state.rs
@@ -344,7 +344,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let y_before = self.y.clone();
         let f_minus = self.dy.clone();
         let s_before = self.s.to_vec();
-        let n_sens = s_before.len();
+        let nsens = s_before.len();
         let reset_t = reset_op.time_derive(&y_before, t);
         let root_t = root_op.time_derive(&y_before, t);
 
@@ -377,7 +377,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let mut root_jac_s = V::zeros(nroots, ctx.clone());
         let mut root_sens = V::zeros(nroots, ctx);
         let nbatch = correction_dir.context().nbatch();
-        let mut s_plus = Vec::with_capacity(n_sens);
+        let mut s_plus = Vec::with_capacity(nsens);
         for (j, s_j_before) in s_before.iter().enumerate() {
             // `basis` is a parameter-space seed, so seed column j's parameter.
             let param_index = rhs.sens_param_index(j);
@@ -452,7 +452,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let y_before = self.y.clone();
         let f_minus = self.dy.clone();
         let s_before = self.s.to_vec();
-        let n_sens = s_before.len();
+        let nsens = s_before.len();
         let reset_t = reset_op.time_derive(&y_before, t);
         let root_t = root_op.time_derive(&y_before, t);
 
@@ -485,7 +485,7 @@ impl<V: Vector> StateRefMut<'_, V> {
         let mut root_jac_s = V::zeros(nroots, ctx.clone());
         let mut root_sens = V::zeros(nroots, ctx);
         let nbatch = correction_dir.context().nbatch();
-        let mut s_plus = Vec::with_capacity(n_sens);
+        let mut s_plus = Vec::with_capacity(nsens);
         for (j, s_j_before) in s_before.iter().enumerate() {
             // `basis` is a parameter-space seed, so seed column j's parameter.
             let param_index = rhs.sens_param_index(j);

--- a/crates/diffsol/src/op/closure_with_sens.rs
+++ b/crates/diffsol/src/op/closure_with_sens.rs
@@ -22,6 +22,7 @@ where
     sparsity: Option<M::Sparsity>,
     sens_sparsity: Option<M::Sparsity>,
     statistics: RefCell<OpStatistics>,
+    sens_params: Option<Vec<usize>>,
     ctx: M::C,
 }
 
@@ -53,6 +54,7 @@ where
             sparsity: None,
             sens_coloring: None,
             sens_sparsity: None,
+            sens_params: None,
             ctx,
         }
     }
@@ -107,6 +109,10 @@ where
         self.calculate_jacobian_sparsity(y0, t0, p);
         self.calculate_sens_sparsity(y0, t0, p);
     }
+
+    fn set_sens_params(&mut self, sens_params: Option<Vec<usize>>) {
+        self.sens_params = sens_params;
+    }
 }
 
 impl<M, F, G, H> Op for ClosureWithSens<M, F, G, H>
@@ -125,6 +131,16 @@ where
     }
     fn nparams(&self) -> usize {
         self.nparams
+    }
+    fn nsens(&self) -> usize {
+        self.sens_params
+            .as_ref()
+            .map_or(self.nparams, |sens_params| sens_params.len())
+    }
+    fn sens_param_index(&self, sens_col: usize) -> usize {
+        self.sens_params
+            .as_ref()
+            .map_or(sens_col, |sens_params| sens_params[sens_col])
     }
     fn statistics(&self) -> OpStatistics {
         self.statistics.borrow().clone()

--- a/crates/diffsol/src/op/mod.rs
+++ b/crates/diffsol/src/op/mod.rs
@@ -55,17 +55,24 @@ pub trait Op {
     /// Defaults to every parameter. Returning fewer is not numerically neutral: the
     /// sensitivity solves feed the step-size and Jacobian-update decisions, so the
     /// trajectory shifts within `rtol`/`atol`. Adjoint gradients are unaffected.
-    fn n_sens(&self) -> usize {
+    ///
+    /// Only the **rhs** op's implementation is read: the solver asks
+    /// `eqn.rhs().nsens()`, so an override on the equations struct's own [`Op`] impl is
+    /// silently ignored.
+    fn nsens(&self) -> usize {
         self.nparams()
     }
 
     /// Return the parameter index that sensitivity column `sens_col` differentiates, in
-    /// `0..nparams()`. Defaults to the identity mapping; override with [`Op::n_sens`] to
-    /// integrate an arbitrary subset of the parameters.
+    /// `0..nparams()`. Defaults to the identity mapping; override alongside [`Op::nsens`]
+    /// to integrate an arbitrary subset of the parameters. Repeated indices are allowed,
+    /// giving duplicate columns.
     ///
     /// Parameter-space quantities stay indexed by parameter, not by column: the `f_p`
     /// matrix keeps its full `nstates x nparams()` layout and the solver maps column to
     /// parameter through this method.
+    ///
+    /// As with [`Op::nsens`], only the rhs op's implementation is read.
     fn sens_param_index(&self, sens_col: usize) -> usize {
         sens_col
     }
@@ -110,8 +117,8 @@ impl<C: Op> Op for ParameterisedOp<'_, C> {
     fn nparams(&self) -> usize {
         self.op.nparams()
     }
-    fn n_sens(&self) -> usize {
-        self.op.n_sens()
+    fn nsens(&self) -> usize {
+        self.op.nsens()
     }
     fn sens_param_index(&self, sens_col: usize) -> usize {
         self.op.sens_param_index(sens_col)
@@ -178,8 +185,8 @@ impl<C: Op> Op for &C {
     fn nparams(&self) -> usize {
         C::nparams(*self)
     }
-    fn n_sens(&self) -> usize {
-        C::n_sens(*self)
+    fn nsens(&self) -> usize {
+        C::nsens(*self)
     }
     fn sens_param_index(&self, sens_col: usize) -> usize {
         C::sens_param_index(*self, sens_col)
@@ -206,8 +213,8 @@ impl<C: Op> Op for &mut C {
     fn nparams(&self) -> usize {
         C::nparams(*self)
     }
-    fn n_sens(&self) -> usize {
-        C::n_sens(*self)
+    fn nsens(&self) -> usize {
+        C::nsens(*self)
     }
     fn sens_param_index(&self, sens_col: usize) -> usize {
         C::sens_param_index(*self, sens_col)
@@ -375,7 +382,7 @@ mod tests {
         fn nparams(&self) -> usize {
             2
         }
-        fn n_sens(&self) -> usize {
+        fn nsens(&self) -> usize {
             1
         }
         fn sens_param_index(&self, _sens_col: usize) -> usize {
@@ -532,20 +539,20 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_ops_preserve_n_sens_override() {
+    fn forwarding_ops_preserve_nsens_override() {
         // Both are defaulted, so a wrapper forwarding `nparams` but not these silently
         // reports the inner op's parameter count and an identity mapping.
         let mut op = ForwardingOp::new();
-        assert_eq!(op.n_sens(), 1);
+        assert_eq!(op.nsens(), 1);
         assert_eq!(op.sens_param_index(0), 1);
 
         let p = crate::NalgebraVec::from_vec(vec![1.0, 2.0], NalgebraContext::default());
         let pop = ParameterisedOp::new(&op, &p);
-        assert_eq!(pop.n_sens(), 1);
+        assert_eq!(pop.nsens(), 1);
         assert_eq!(pop.sens_param_index(0), 1);
-        assert_eq!(Op::n_sens(&&op), 1);
+        assert_eq!(Op::nsens(&&op), 1);
         assert_eq!(Op::sens_param_index(&&op, 0), 1);
-        assert_eq!(Op::n_sens(&&mut op), 1);
+        assert_eq!(Op::nsens(&&mut op), 1);
         assert_eq!(Op::sens_param_index(&&mut op, 0), 1);
     }
 }

--- a/crates/diffsol/src/op/mod.rs
+++ b/crates/diffsol/src/op/mod.rs
@@ -90,6 +90,9 @@ pub trait BuilderOp: Op {
     fn set_nparams(&mut self, nparams: usize);
     fn set_nout(&mut self, nout: usize);
     fn calculate_sparsity(&mut self, y0: &Self::V, t0: Self::T, p: &Self::V);
+    /// Set the parameters to integrate sensitivities for, backing [`Op::nsens`] and [`Op::sens_param_index`].
+    /// Defaults to a no-op, as only the rhs op is consulted for them.
+    fn set_sens_params(&mut self, _sens_params: Option<Vec<usize>>) {}
 }
 
 impl<C: Op> Op for ParameterisedOp<'_, C> {

--- a/crates/diffsol/src/op/mod.rs
+++ b/crates/diffsol/src/op/mod.rs
@@ -50,6 +50,26 @@ pub trait Op {
     /// Return the number of parameters of the operator.
     fn nparams(&self) -> usize;
 
+    /// Return the number of forward sensitivity columns to integrate, in `0..=nparams()`.
+    ///
+    /// Defaults to every parameter. Returning fewer is not numerically neutral: the
+    /// sensitivity solves feed the step-size and Jacobian-update decisions, so the
+    /// trajectory shifts within `rtol`/`atol`. Adjoint gradients are unaffected.
+    fn n_sens(&self) -> usize {
+        self.nparams()
+    }
+
+    /// Return the parameter index that sensitivity column `sens_col` differentiates, in
+    /// `0..nparams()`. Defaults to the identity mapping; override with [`Op::n_sens`] to
+    /// integrate an arbitrary subset of the parameters.
+    ///
+    /// Parameter-space quantities stay indexed by parameter, not by column: the `f_p`
+    /// matrix keeps its full `nstates x nparams()` layout and the solver maps column to
+    /// parameter through this method.
+    fn sens_param_index(&self, sens_col: usize) -> usize {
+        sens_col
+    }
+
     /// Return statistics about the operator (e.g. how many times it was called, how many times the jacobian was computed, etc.)
     fn statistics(&self) -> OpStatistics {
         OpStatistics::default()
@@ -89,6 +109,12 @@ impl<C: Op> Op for ParameterisedOp<'_, C> {
     }
     fn nparams(&self) -> usize {
         self.op.nparams()
+    }
+    fn n_sens(&self) -> usize {
+        self.op.n_sens()
+    }
+    fn sens_param_index(&self, sens_col: usize) -> usize {
+        self.op.sens_param_index(sens_col)
     }
     fn statistics(&self) -> OpStatistics {
         self.op.statistics()
@@ -152,6 +178,12 @@ impl<C: Op> Op for &C {
     fn nparams(&self) -> usize {
         C::nparams(*self)
     }
+    fn n_sens(&self) -> usize {
+        C::n_sens(*self)
+    }
+    fn sens_param_index(&self, sens_col: usize) -> usize {
+        C::sens_param_index(*self, sens_col)
+    }
     fn statistics(&self) -> OpStatistics {
         C::statistics(*self)
     }
@@ -173,6 +205,12 @@ impl<C: Op> Op for &mut C {
     }
     fn nparams(&self) -> usize {
         C::nparams(*self)
+    }
+    fn n_sens(&self) -> usize {
+        C::n_sens(*self)
+    }
+    fn sens_param_index(&self, sens_col: usize) -> usize {
+        C::sens_param_index(*self, sens_col)
     }
     fn statistics(&self) -> OpStatistics {
         C::statistics(*self)
@@ -337,6 +375,12 @@ mod tests {
         fn nparams(&self) -> usize {
             2
         }
+        fn n_sens(&self) -> usize {
+            1
+        }
+        fn sens_param_index(&self, _sens_col: usize) -> usize {
+            1
+        }
         fn statistics(&self) -> OpStatistics {
             self.stats.borrow().clone()
         }
@@ -485,5 +529,23 @@ mod tests {
         assert_eq!(op_mut.nstates(), 2);
         assert_eq!(op_mut.nout(), 2);
         assert_eq!(op_mut.nparams(), 2);
+    }
+
+    #[test]
+    fn forwarding_ops_preserve_n_sens_override() {
+        // Both are defaulted, so a wrapper forwarding `nparams` but not these silently
+        // reports the inner op's parameter count and an identity mapping.
+        let mut op = ForwardingOp::new();
+        assert_eq!(op.n_sens(), 1);
+        assert_eq!(op.sens_param_index(0), 1);
+
+        let p = crate::NalgebraVec::from_vec(vec![1.0, 2.0], NalgebraContext::default());
+        let pop = ParameterisedOp::new(&op, &p);
+        assert_eq!(pop.n_sens(), 1);
+        assert_eq!(pop.sens_param_index(0), 1);
+        assert_eq!(Op::n_sens(&&op), 1);
+        assert_eq!(Op::sens_param_index(&&op, 0), 1);
+        assert_eq!(Op::n_sens(&&mut op), 1);
+        assert_eq!(Op::sens_param_index(&&mut op, 0), 1);
     }
 }

--- a/crates/diffsol/src/op/mod.rs
+++ b/crates/diffsol/src/op/mod.rs
@@ -50,29 +50,18 @@ pub trait Op {
     /// Return the number of parameters of the operator.
     fn nparams(&self) -> usize;
 
-    /// Return the number of forward sensitivity columns to integrate, in `0..=nparams()`.
+    /// Return the number of forward sensitivity columns to integrate, in `0..=nparams()` (defaults to every parameter).
     ///
-    /// Defaults to every parameter. Returning fewer is not numerically neutral: the
-    /// sensitivity solves feed the step-size and Jacobian-update decisions, so the
-    /// trajectory shifts within `rtol`/`atol`. Adjoint gradients are unaffected.
-    ///
-    /// Only the **rhs** op's implementation is read: the solver asks
-    /// `eqn.rhs().nsens()`, so an override on the equations struct's own [`Op`] impl is
-    /// silently ignored.
+    /// Only the rhs op is consulted, as the solver calls `eqn.rhs().nsens()`.
+    /// Integrating fewer columns shifts the trajectory within `rtol`/`atol`, since the sensitivity solves feed step-size and Jacobian-update decisions.
     fn nsens(&self) -> usize {
         self.nparams()
     }
 
-    /// Return the parameter index that sensitivity column `sens_col` differentiates, in
-    /// `0..nparams()`. Defaults to the identity mapping; override alongside [`Op::nsens`]
-    /// to integrate an arbitrary subset of the parameters. Repeated indices are allowed,
-    /// giving duplicate columns.
+    /// Return the parameter index that sensitivity column `sens_col` differentiates, in `0..nparams()` (defaults to the identity mapping).
     ///
-    /// Parameter-space quantities stay indexed by parameter, not by column: the `f_p`
-    /// matrix keeps its full `nstates x nparams()` layout and the solver maps column to
-    /// parameter through this method.
-    ///
-    /// As with [`Op::nsens`], only the rhs op's implementation is read.
+    /// Override alongside [`Op::nsens`] to integrate a subset of the parameters; repeated indices give duplicate columns.
+    /// Parameter-space quantities stay indexed by parameter, so `f_p` keeps its full `nstates x nparams()` layout.
     fn sens_param_index(&self, sens_col: usize) -> usize {
         sens_col
     }
@@ -540,8 +529,7 @@ mod tests {
 
     #[test]
     fn forwarding_ops_preserve_nsens_override() {
-        // Both are defaulted, so a wrapper forwarding `nparams` but not these silently
-        // reports the inner op's parameter count and an identity mapping.
+        // both are defaulted, so a wrapper that forgets to forward them falls back to nparams and the identity mapping
         let mut op = ForwardingOp::new();
         assert_eq!(op.nsens(), 1);
         assert_eq!(op.sens_param_index(0), 1);


### PR DESCRIPTION
Adds `Op::nsens` and `Op::sens_param_index` so a forward sensitivity solve can integrate a chosen subset of the parameters instead of one column per parameter. Both default to current behaviour (`nsens() == nparams()`), so existing implementations are unchanged.

`OdeBuilder::sens_params` sets this for builder-constructed problems, backed by a defaulted `BuilderOp::set_sens_params` that only `ClosureWithSens` implements:

  ```rust
  let problem = OdeBuilder::<M>::new()
      .p([0.5, 99.0, 2.0])
      .sens_rtol(1e-8).sens_atol([1e-8])
      .sens_params([2, 0])   // column 0 -> p[2], column 1 -> p[0]
      .rhs_sens_implicit(rhs, rhs_jac, rhs_sens)
      .init_sens(init, init_sens, 1)
      .build()?;

  let (y, sens, _stop) = problem.bdf_sens::<LS>()?.solve_dense_sensitivities(&t_eval)?;
  assert_eq!(problem.eqn.rhs().nparams(), 3);   // unchanged
  assert_eq!(sens.len(), 2);                    // sens[0] = dx/dp[2], sens[1] = dx/dp[0]
  ```

Hand-implemented equations override the two `Op` methods on their rhs op directly. Only the rhs is consulted (`eqn.rhs().nsens()`), so an override on the equations struct's own `Op` impl is ignored. `.sens_params()` is likewise ignored on an rhs not built by `rhs_sens_implicit`, since `set_sens_params` defaults to a no-op. Happy to make that a build-time error instead!